### PR TITLE
Omit layout GPU resources in CPU mode

### DIFF
--- a/helm/templates/_helpers/app/layout-inference.tpl
+++ b/helm/templates/_helpers/app/layout-inference.tpl
@@ -236,7 +236,21 @@ true
   {{- $_ := set $cfg "nodeSelector" (get $in "nodeSelector") -}}
 {{- end -}}
 {{- if and (hasKey $in "resources") (not (empty (get $in "resources"))) -}}
-  {{- $_ := set $cfg "resources" (get $in "resources") -}}
+  {{- $resources := deepCopy (get $in "resources") -}}
+  {{- if eq (include "groundx.layout.inference.deviceType" .) "cpu" -}}
+    {{- range $kind := list "limits" "requests" -}}
+      {{- $resourceSet := get $resources $kind -}}
+      {{- if kindIs "map" $resourceSet -}}
+        {{- $_ := unset $resourceSet "nvidia.com/gpu" -}}
+        {{- if empty $resourceSet -}}
+          {{- $_ := unset $resources $kind -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not (empty $resources) -}}
+    {{- $_ := set $cfg "resources" $resources -}}
+  {{- end -}}
 {{- end -}}
 {{- if and (hasKey $in "securityContext") (not (empty (get $in "securityContext"))) -}}
   {{- $_ := set $cfg "securityContext" (get $in "securityContext") -}}

--- a/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/design.md
+++ b/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The chart stores the layout inference runtime mode in `layout.inference.deviceType`. The helper defaults that field to `cuda`, and config templates pass it into the application config.
+
+Container resources are rendered separately from `layout.inference.resources`. The default values include:
+
+- `resources.limits.nvidia.com/gpu: 1`
+- `resources.requests.nvidia.com/gpu: 1`
+
+So a user can correctly set `deviceType: cpu` and still get a pod that asks Kubernetes for a GPU.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `deviceType: cpu` sufficient to stop `layout-inference` from requesting GPU resources.
+- Preserve CPU and memory requests/limits.
+- Keep non-CPU rendering unchanged.
+- Keep node placement explicitly controlled by existing node, affinity, toleration, and node selector values.
+- Cover the behavior with Helm rendering tests.
+
+**Non-Goals:**
+
+- Do not change runtime application behavior inside the layout image.
+- Do not resize the default CPU or memory values.
+- Do not move pods between node groups based on `deviceType`.
+- Do not solve general cluster capacity, OpenShift SCC, Strimzi API-version, or node-taint issues.
+- Do not change ranker or summary inference behavior unless follow-up testing shows they have the same CPU-mode contract.
+
+## Decisions
+
+Use render-time resource normalization for `layout-inference`.
+
+When `include "groundx.layout.inference.deviceType" .` resolves to `cpu`, the chart should deep-copy `layout.inference.resources`, remove NVIDIA extended resource keys from `requests` and `limits`, then set the sanitized resources on the service settings map.
+
+This is preferred over changing defaults because defaults still need GPU resources for normal non-CPU deployments. It is also preferred over documenting `nvidia.com/gpu: "0"` because users should not need to know Kubernetes extended-resource edge cases to select CPU mode.
+
+Render omission is preferred over rendering `0`: a CPU pod should not include GPU extended resources at all.
+
+`deviceType` is a device-resource mode, not a scheduling policy. The chart should not infer a CPU node, remove affinity, remove tolerations, or alter node selectors just because `deviceType: cpu` is set. Deployers already configure node placement explicitly.
+
+This change should not add a schema enum for `deviceType`. It only gives `cpu` special resource-rendering behavior and leaves all other values on the existing path.
+
+## Test Strategy
+
+Add targeted Helm unittest assertions for the rendered `layout-inference` Deployment. Snapshot updates alone are not enough because `templates/app/inference.yaml` renders multiple inference Deployments.
+
+The CPU-mode tests should use `documentSelector` with `metadata.name: layout-inference`, then assert:
+
+- `spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]` does not exist;
+- `spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]` does not exist;
+- CPU and memory resources still exist where defaults or overrides provide them.
+
+Add fixtures for both default CPU mode and the customer repro shape where `deviceType: cpu` is combined with a partial `layout.inference.resources` override. At minimum, cover a GPU limit set to `0` and a non-GPU limit override that omits the GPU key, because Helm map merging can otherwise retain default GPU requests or limits.
+
+The OpenShift render check should also inspect the rendered `layout-inference` Deployment, not only confirm that Helm renders. It should fail if that Deployment contains `nvidia.com/gpu`.
+
+## Risks / Trade-offs
+
+- A CPU-mode deployment with intentionally supplied GPU keys will have those keys ignored for `layout-inference`. That is intentional because `deviceType: cpu` is the clearer source of truth.
+- Helm map mutation can accidentally modify shared values. The implementation should use a deep copy before removing keys.
+- A CPU-mode deployment still needs correct node placement values for the target cluster. This change only removes GPU resource requests/limits.
+
+## Branch Scope
+
+This is a chart source fix for the 0.2.7 branch.
+
+The implementation should update `src/groundx` and sync the matching `helm/` mirror file because the production Helm gate checks mirror parity. Packaging, published chart replacement, and the release process are outside this plan.
+
+No data migration is expected.
+
+## Alternatives Considered
+
+1. Document the current workaround: set both GPU request and limit to `0`.
+   - Simple, but keeps the footgun and still makes CPU mode surprising.
+2. Remove GPU defaults from chart values.
+   - Breaks default non-CPU deployments.
+3. Normalize resources when `deviceType: cpu`.
+   - Best fit. CPU mode becomes self-contained while GPU defaults remain intact.

--- a/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/proposal.md
+++ b/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`layout-inference` can be configured with `layout.inference.deviceType: cpu`, but the chart still renders the default GPU resources from `layout.inference.resources`.
+
+That means a CPU layout deployment can still request `nvidia.com/gpu: 1` and remain Pending on CPU-only OpenShift clusters. Setting only the GPU limit to `0`, omitting the GPU key in an override, or relying on `deviceType: cpu` is not enough because the chart defaults still supply the GPU request/limit.
+
+## What Changes
+
+When `layout.inference.deviceType` is `cpu`, the chart will render `layout-inference` container resources without NVIDIA GPU extended resource keys.
+
+The change should:
+
+- preserve non-GPU resource settings such as CPU and memory;
+- remove GPU keys from both `resources.requests` and `resources.limits`;
+- make the CPU intent win even if a values file also includes GPU keys;
+- make the CPU intent win when Helm merges a partial resource override with the chart defaults;
+- keep non-CPU behavior unchanged when `deviceType` is unset or not `cpu`;
+- leave node placement, affinity, tolerations, and node selectors under explicit values control;
+- update targeted Helm tests and OpenShift render validation so the CPU rendering path fails if GPU resources reappear.
+
+The preferred rendered behavior is to omit the GPU keys, not render them as `0`.
+
+## Capabilities
+
+### New Capabilities
+
+- `layout-inference-cpu-resources`: defines how the Helm chart renders `layout-inference` resources when CPU device mode is selected.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected chart source:
+  - `src/groundx/templates/_helpers/app/layout-inference.tpl`
+  - `helm/templates/_helpers/app/layout-inference.tpl`
+  - possibly `src/groundx/templates/_helpers/elements/containerresources.tpl` if a reusable helper is cleaner
+  - `src/groundx/tests/inference_test.yaml`
+  - `src/groundx/tests/files/values.layout-inference.cpu*.yaml`
+  - `src/groundx/tests/__snapshot__/inference_test.yaml.snap`
+- Schema impact:
+  - no schema change expected
+- Blast radius:
+  - limited to rendered `layout-inference` Deployment resources
+  - CPU mode stops requesting GPU resources
+  - CPU mode does not change configured node placement
+  - non-CPU mode should render exactly as before
+- Environments:
+  - affects any Helm install or upgrade using `layout.inference.deviceType: cpu`
+  - no data or stateful resource migration
+- Branch scope:
+  - fix in the 0.2.7 branch only
+  - sync the `helm/` mirror file required by the production Helm gate
+  - do not include chart release, packaging, or published chart replacement work in this plan
+- Rollback:
+  - revert the chart/template change, or set explicit GPU resources when running GPU mode
+- Open design questions:
+  - none

--- a/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/specs/layout-inference-cpu-resources/spec.md
+++ b/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/specs/layout-inference-cpu-resources/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: CPU layout inference omits GPU resources
+
+When `layout.inference.deviceType` is `cpu`, the Helm chart SHALL render the `layout-inference` container without NVIDIA GPU extended resource keys in `resources.requests` or `resources.limits`.
+
+#### Scenario: CPU mode uses default resources
+
+- **GIVEN** the chart default `layout.inference.resources` includes `nvidia.com/gpu`
+- **WHEN** the chart is rendered with `layout.inference.deviceType: cpu`
+- **THEN** the `layout-inference` container resources do not include `nvidia.com/gpu` in requests or limits
+- **AND** non-GPU resources such as CPU and memory remain rendered
+
+#### Scenario: CPU mode overrides explicit GPU resources
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file sets GPU keys under `layout.inference.resources.requests` or `layout.inference.resources.limits`
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources do not include GPU resource keys
+
+#### Scenario: CPU mode overrides a zero GPU limit
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file sets the `nvidia.com/gpu` key under `layout.inference.resources.limits` to `0`
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources do not include `nvidia.com/gpu` in requests or limits
+
+#### Scenario: CPU mode overrides partial non-GPU resources
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file overrides a non-GPU resource limit without setting a GPU key
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources do not include default GPU resource keys
+- **AND** non-GPU resources remain rendered
+
+### Requirement: Non-CPU layout inference keeps GPU resources
+
+When `layout.inference.deviceType` is unset or not set to `cpu`, the Helm chart SHALL keep the existing `layout-inference` GPU resource rendering behavior.
+
+#### Scenario: Default mode renders GPU resources
+
+- **GIVEN** the chart defaults are used
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources include `nvidia.com/gpu: 1` in requests and limits
+
+### Requirement: CPU layout inference preserves node placement
+
+When `layout.inference.deviceType` is `cpu`, the Helm chart SHALL NOT change node placement fields based on the device type.
+
+#### Scenario: CPU mode keeps explicit scheduling configuration
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file sets node, affinity, toleration, or node selector settings
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` Deployment keeps those scheduling settings
+- **AND** the chart does not infer a different node group from `deviceType`
+
+### Requirement: CPU is the only special resource mode
+
+The Helm chart SHALL apply resource normalization only when `layout.inference.deviceType` is `cpu`.
+
+All other `layout.inference.deviceType` values SHALL keep the existing resource rendering behavior.
+
+#### Scenario: CPU mode is selected
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **WHEN** the chart is rendered
+- **THEN** CPU resource normalization applies
+
+#### Scenario: Other device type values keep existing behavior
+
+- **GIVEN** a values file leaves `layout.inference.deviceType` unset or sets it to a value other than `cpu`
+- **WHEN** the chart is rendered
+- **THEN** GPU resource rendering is preserved

--- a/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/tasks.md
+++ b/openspec/changes/archive/2026-07-09-auto-disable-layout-gpu-on-cpu/tasks.md
@@ -1,0 +1,29 @@
+## 1. Chart Behavior
+
+- [x] 1.1 Add a layout inference resource normalization path in `src/groundx` that removes NVIDIA GPU resource keys when `layout.inference.deviceType: cpu`.
+- [x] 1.2 Preserve existing CPU and memory resource values when GPU keys are removed.
+- [x] 1.3 Keep non-CPU rendering unchanged.
+- [x] 1.4 Do not change node, affinity, toleration, or node selector rendering based on `deviceType`.
+- [x] 1.5 Sync the matching `helm/` mirror helper required by the production Helm gate, without packaging or publishing a chart release.
+
+## 2. Tests
+
+- [x] 2.1 Add Helm unittest fixture coverage for `layout.inference.deviceType: cpu` with default chart resources.
+- [x] 2.2 Add Helm unittest fixture coverage for the customer repro shape: `layout.inference.deviceType: cpu` plus a partial `layout.inference.resources` override, including `nvidia.com/gpu: 0` under `layout.inference.resources.limits`.
+- [x] 2.3 Add Helm unittest fixture coverage for `layout.inference.deviceType: cpu` plus a non-GPU resource override that omits the GPU key.
+- [x] 2.4 Target the rendered `layout-inference` Deployment by document selector, not by snapshot position or a generic multi-document assertion.
+- [x] 2.5 Assert that the selected `layout-inference` container does not contain `nvidia.com/gpu` in `resources.requests` or `resources.limits` for CPU mode.
+- [x] 2.6 Assert that the selected `layout-inference` container keeps CPU and memory resources for CPU mode.
+- [x] 2.7 Assert that CPU mode does not change rendered node placement fields.
+- [x] 2.8 Assert that the default non-CPU rendering still includes `nvidia.com/gpu: 1`.
+- [x] 2.9 Regenerate snapshots with `helm unittest -u src/groundx` after targeted assertions pass.
+
+## 3. Validation
+
+- [x] 3.1 Run `helm unittest src/groundx`.
+- [x] 3.2 Run `helm template src/groundx -f src/groundx/values/minikube/values.yaml`.
+- [x] 3.3 Run an OpenShift render check using `src/groundx/values/openshift/values.yaml` plus `layout.inference.deviceType=cpu`.
+- [x] 3.4 In that OpenShift render output, inspect the `layout-inference` Deployment and fail validation if `nvidia.com/gpu` appears in the selected Deployment.
+- [x] 3.5 Run `helm lint src/groundx`.
+- [x] 3.6 Run `npx --yes @fission-ai/openspec@latest validate auto-disable-layout-gpu-on-cpu --strict`.
+- [x] 3.7 Run `.build/bin/validate-helm.sh`.

--- a/openspec/specs/layout-inference-cpu-resources/spec.md
+++ b/openspec/specs/layout-inference-cpu-resources/spec.md
@@ -1,0 +1,78 @@
+# layout-inference-cpu-resources Specification
+
+## Purpose
+Defines how the Helm chart renders `layout-inference` container resources when CPU device mode is selected.
+
+## Requirements
+### Requirement: CPU layout inference omits GPU resources
+
+When `layout.inference.deviceType` is `cpu`, the Helm chart SHALL render the `layout-inference` container without NVIDIA GPU extended resource keys in `resources.requests` or `resources.limits`.
+
+#### Scenario: CPU mode uses default resources
+
+- **GIVEN** the chart default `layout.inference.resources` includes `nvidia.com/gpu`
+- **WHEN** the chart is rendered with `layout.inference.deviceType: cpu`
+- **THEN** the `layout-inference` container resources do not include `nvidia.com/gpu` in requests or limits
+- **AND** non-GPU resources such as CPU and memory remain rendered
+
+#### Scenario: CPU mode overrides explicit GPU resources
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file sets GPU keys under `layout.inference.resources.requests` or `layout.inference.resources.limits`
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources do not include GPU resource keys
+
+#### Scenario: CPU mode overrides a zero GPU limit
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file sets the `nvidia.com/gpu` key under `layout.inference.resources.limits` to `0`
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources do not include `nvidia.com/gpu` in requests or limits
+
+#### Scenario: CPU mode overrides partial non-GPU resources
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file overrides a non-GPU resource limit without setting a GPU key
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources do not include default GPU resource keys
+- **AND** non-GPU resources remain rendered
+
+### Requirement: Non-CPU layout inference keeps GPU resources
+
+When `layout.inference.deviceType` is unset or not set to `cpu`, the Helm chart SHALL keep the existing `layout-inference` GPU resource rendering behavior.
+
+#### Scenario: Default mode renders GPU resources
+
+- **GIVEN** the chart defaults are used
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` container resources include `nvidia.com/gpu: 1` in requests and limits
+
+### Requirement: CPU layout inference preserves node placement
+
+When `layout.inference.deviceType` is `cpu`, the Helm chart SHALL NOT change node placement fields based on the device type.
+
+#### Scenario: CPU mode keeps explicit scheduling configuration
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **AND** the same values file sets node, affinity, toleration, or node selector settings
+- **WHEN** the chart is rendered
+- **THEN** the `layout-inference` Deployment keeps those scheduling settings
+- **AND** the chart does not infer a different node group from `deviceType`
+
+### Requirement: CPU is the only special resource mode
+
+The Helm chart SHALL apply resource normalization only when `layout.inference.deviceType` is `cpu`.
+
+All other `layout.inference.deviceType` values SHALL keep the existing resource rendering behavior.
+
+#### Scenario: CPU mode is selected
+
+- **GIVEN** a values file sets `layout.inference.deviceType: cpu`
+- **WHEN** the chart is rendered
+- **THEN** CPU resource normalization applies
+
+#### Scenario: Other device type values keep existing behavior
+
+- **GIVEN** a values file leaves `layout.inference.deviceType` unset or sets it to a value other than `cpu`
+- **WHEN** the chart is rendered
+- **THEN** GPU resource rendering is preserved

--- a/src/groundx/templates/_helpers/app/layout-inference.tpl
+++ b/src/groundx/templates/_helpers/app/layout-inference.tpl
@@ -236,7 +236,21 @@ true
   {{- $_ := set $cfg "nodeSelector" (get $in "nodeSelector") -}}
 {{- end -}}
 {{- if and (hasKey $in "resources") (not (empty (get $in "resources"))) -}}
-  {{- $_ := set $cfg "resources" (get $in "resources") -}}
+  {{- $resources := deepCopy (get $in "resources") -}}
+  {{- if eq (include "groundx.layout.inference.deviceType" .) "cpu" -}}
+    {{- range $kind := list "limits" "requests" -}}
+      {{- $resourceSet := get $resources $kind -}}
+      {{- if kindIs "map" $resourceSet -}}
+        {{- $_ := unset $resourceSet "nvidia.com/gpu" -}}
+        {{- if empty $resourceSet -}}
+          {{- $_ := unset $resources $kind -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not (empty $resources) -}}
+    {{- $_ := set $cfg "resources" $resources -}}
+  {{- end -}}
 {{- end -}}
 {{- if and (hasKey $in "securityContext") (not (empty (get $in "securityContext"))) -}}
   {{- $_ := set $cfg "securityContext" (get $in "securityContext") -}}

--- a/src/groundx/tests/__snapshot__/inference_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/inference_test.yaml.snap
@@ -5847,11 +5847,9 @@
               resources:
                 limits:
                   memory: 12Gi
-                  nvidia.com/gpu: 1
                 requests:
                   cpu: 500m
                   memory: 2Gi
-                  nvidia.com/gpu: 1
               securityContext:
                 readOnlyRootFilesystem: true
               volumeMounts:

--- a/src/groundx/tests/files/values.layout-inference.cpu-non-gpu-resources.yaml
+++ b/src/groundx/tests/files/values.layout-inference.cpu-non-gpu-resources.yaml
@@ -1,0 +1,9 @@
+layout:
+  inference:
+    deviceType: cpu
+    resources:
+      limits:
+        memory: 10Gi
+      requests:
+        cpu: 750m
+        memory: 3Gi

--- a/src/groundx/tests/files/values.layout-inference.cpu-placement.yaml
+++ b/src/groundx/tests/files/values.layout-inference.cpu-placement.yaml
@@ -1,0 +1,11 @@
+layout:
+  inference:
+    deviceType: cpu
+    node: custom-layout-node
+    nodeSelector:
+      workload: layout-cpu
+    tolerations:
+      - key: workload
+        operator: Equal
+        value: layout-cpu
+        effect: NoSchedule

--- a/src/groundx/tests/files/values.layout-inference.cpu-zero-gpu.yaml
+++ b/src/groundx/tests/files/values.layout-inference.cpu-zero-gpu.yaml
@@ -1,0 +1,6 @@
+layout:
+  inference:
+    deviceType: cpu
+    resources:
+      limits:
+        nvidia.com/gpu: 0

--- a/src/groundx/tests/files/values.layout-inference.cpu.yaml
+++ b/src/groundx/tests/files/values.layout-inference.cpu.yaml
@@ -1,0 +1,3 @@
+layout:
+  inference:
+    deviceType: cpu

--- a/src/groundx/tests/inference_test.yaml
+++ b/src/groundx/tests/inference_test.yaml
@@ -103,3 +103,110 @@ tests:
       - ./files/values.workspace.enabled.yaml
     asserts:
       - matchSnapshot: {}
+  - it: "layout cpu mode omits default gpu resources"
+    templates:
+      - ../templates/app/inference.yaml
+    values:
+      - ../values.yaml
+      - ./files/values.layout-inference.cpu.yaml
+    documentSelector:
+      path: metadata.name
+      value: layout-inference
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 12Gi
+  - it: "layout cpu mode omits zero gpu override"
+    templates:
+      - ../templates/app/inference.yaml
+    values:
+      - ../values.yaml
+      - ./files/values.layout-inference.cpu-zero-gpu.yaml
+    documentSelector:
+      path: metadata.name
+      value: layout-inference
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 12Gi
+  - it: "layout cpu mode omits gpu after partial non-gpu override"
+    templates:
+      - ../templates/app/inference.yaml
+    values:
+      - ../values.yaml
+      - ./files/values.layout-inference.cpu-non-gpu-resources.yaml
+    documentSelector:
+      path: metadata.name
+      value: layout-inference
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 750m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 3Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 10Gi
+  - it: "layout cpu mode preserves explicit node placement"
+    templates:
+      - ../templates/app/inference.yaml
+    values:
+      - ../values.yaml
+      - ./files/values.layout-inference.cpu-placement.yaml
+    documentSelector:
+      path: metadata.name
+      value: layout-inference
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.workload
+          value: layout-cpu
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: custom-layout-node
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: workload
+            operator: Equal
+            value: layout-cpu
+            effect: NoSchedule
+  - it: "default layout inference keeps gpu resources"
+    templates:
+      - ../templates/app/inference.yaml
+    values:
+      - ../values.yaml
+    documentSelector:
+      path: metadata.name
+      value: layout-inference
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 1


### PR DESCRIPTION
## Summary

- Strip `nvidia.com/gpu` from `layout-inference` requests and limits when `layout.inference.deviceType: cpu`.
- Preserve CPU/memory resources and explicit node placement settings.
- Keep default non-CPU rendering on the existing GPU path.
- Sync the required `helm/` mirror helper and add targeted Helm unittest fixtures for the CPU-mode repro cases.
- Archive the completed OpenSpec change in this PR and promote the settled behavior into `openspec/specs/layout-inference-cpu-resources/spec.md`.

## Root Cause

`deviceType: cpu` changed the app config, but the chart still rendered the default GPU resource request and limit. On CPU-only clusters, that left `layout-inference` Pending because Kubernetes still saw `nvidia.com/gpu` in the pod resources.

## Validation

- `.build/bin/validate-helm.sh --junit`
- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@latest validate --all --strict --json`
- OpenShift render check with `src/groundx/values/openshift/values.yaml` plus `--set layout.inference.deviceType=cpu`; selected `layout-inference` Deployment has no `nvidia.com/gpu`.
- `git diff --cached --check`
