### PR TITLE
Expose document summary image limit in chart

### DIFF
--- a/helm/templates/resources/config-yaml.yaml
+++ b/helm/templates/resources/config-yaml.yaml
@@ -174,6 +174,9 @@ data:
         {{- if hasKey $e "baseUrl" }}
         baseURL: {{ get $e "baseUrl" }}
         {{- end }}
+        {{- if hasKey $e "maxImages" }}
+        maxImages: {{ get $e "maxImages" }}
+        {{- end }}
         {{- if hasKey $e "maxInputTokens" }}
         maxInputTokens: {{ get $e "maxInputTokens" }}
         {{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -96,6 +96,7 @@
             "baseUrl": { "type": "string" },
             "dataType": { "type": "string" },
             "engineId": { "type": "string" },
+            "maxImages": { "type": "integer", "minimum": 1 },
             "maxInputTokens": { "type": "integer" },
             "maxOutputTokens": { "type": "integer" },
             "maxRequests": { "type": "integer" },

--- a/openspec/changes/expose-doc-summary-image-limit/design.md
+++ b/openspec/changes/expose-doc-summary-image-limit/design.md
@@ -1,0 +1,89 @@
+# Expose Document Summary Image Limit Design
+
+## Goals
+
+- Let on-prem operators configure the document-summary page image limit through
+  values.
+- Render the value into the app's `config.yaml` under the existing `engines`
+  block.
+- Keep the chart change small and isolated to config rendering.
+- Preserve strict schema validation.
+
+## Non-Goals
+
+- No app runtime changes in this repo.
+- No new pod, service, queue, secret, or stateful resource.
+- No model server tuning.
+- No chart publish operation.
+
+## Source Evidence To Re-Read Before Implementation
+
+- `AGENTS.md`
+- `openspec/config.yaml`
+- `src/groundx/values.yaml`
+- `src/groundx/values.schema.json`
+- `src/groundx/templates/_helpers/engines.tpl`
+- `src/groundx/templates/resources/config-yaml.yaml`
+- matching files under `helm/` for manual mirror sync
+- GroundX Studio Harness on-prem `values-yaml.md`
+- `cashbot-go` OpenSpec change `limit-doc-summary-page-images`
+
+## Proposed Values Surface
+
+Add:
+
+```yaml
+engines:
+  default:
+    maxImages: 30
+```
+
+The field means: maximum page image attachments the `cashbot-go` runtime should
+send in one document-summary request when using this engine config.
+
+This chart does not enforce request behavior. It only renders config.
+
+## Rendered Config
+
+When `engines.default.maxImages` exists, render:
+
+```yaml
+engines:
+  default:
+    maxImages: 30
+```
+
+in the application `config.yaml` engine entry.
+
+When operators provide `maxImages`, preserve and render their supplied value.
+When operators omit `maxImages`, do not render the field; the app runtime default
+of 30 remains the source of default behavior.
+
+## Rollout
+
+1. Merge and deploy the `cashbot-go` app change first or in the same release
+   train.
+2. Merge the chart config exposure.
+3. Upgrade a non-production self-hosted environment and confirm rendered
+   `config.yaml` includes `engines.default.maxImages` when the value is set.
+4. Confirm the running app image consumes the field before claiming the provider
+   image-limit issue is fixed.
+5. Promote to production/self-hosted customer environments.
+
+## Rollback
+
+The field is config-only. Removing it or rolling back the chart returns the app
+to its built-in default once the runtime change exists. No data migration or
+stateful rollback is needed.
+
+## Validation
+
+- `helm lint src/groundx`
+- `helm template src/groundx -f src/groundx/values/minikube/values.yaml`
+- `helm unittest src/groundx`
+- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate --all --strict --json`
+- `git diff --check`
+- source/mirror diff review for `src/groundx` and `helm/`
+
+If `helm-unittest` snapshots change, regenerate them with `helm unittest -u
+src/groundx`; do not edit snapshots by hand.

--- a/openspec/changes/expose-doc-summary-image-limit/proposal.md
+++ b/openspec/changes/expose-doc-summary-image-limit/proposal.md
@@ -1,0 +1,62 @@
+# Expose Document Summary Image Limit
+
+## Why
+
+FRA-76 needs self-hosted deployments to tune the same document-summary page
+image limit used by hosted `cashbot-go`. The runtime fix belongs in
+`cashbot-go`; this chart change only renders the app config value so on-prem
+operators can configure it through values.
+
+## Blast Radius
+
+- Affects chart rendering of the application `config.yaml`.
+- Affects self-hosted clusters when the chart is upgraded and the app image
+  contains the matching `cashbot-go` runtime support.
+- Does not change Kubernetes workload shape, storage, services, RBAC, HPA, or
+  stateful resources.
+- Does not fix runtime behavior by itself if the deployed app image does not
+  consume `engines.*.maxImages`.
+
+## What Changes
+
+- Permit positive integer `engines.default.maxImages` values in
+  `src/groundx/values.schema.json`.
+- Reject non-positive configured values during Helm schema validation.
+- Render `maxImages` into the generated application `config.yaml` engine block
+  in `src/groundx/templates/resources/config-yaml.yaml` only when an operator
+  sets it.
+- Mirror source chart changes to `helm/` during implementation.
+- Update Helm snapshots if rendered output changes.
+
+## Out Of Scope
+
+- App-side enforcement. That is tracked in `cashbot-go` OpenSpec change
+  `limit-doc-summary-page-images`.
+- Changing summary model image limits or vLLM server kwargs.
+- Changing pod resources, queues, HPA, or deployment topology.
+- Editing generated snapshot files by hand.
+- Publishing chart packages.
+
+## Affected Environments
+
+- Dev/staging/prod on-prem environments only after chart upgrade.
+- Hosted cloud only if it consumes the same app config key outside this chart.
+
+There is no data or stateful resource impact.
+
+## Rollback / Rollforward
+
+Rollback:
+
+- remove or ignore `engines.default.maxImages`;
+- or deploy the previous chart.
+
+Rollforward:
+
+- upgrade to the chart that renders the field;
+- deploy an app image that consumes the field;
+- set a deployment-specific value if the default 30 does not match the provider.
+
+## Open Design Questions
+
+None. The chart exposes config only. Runtime behavior is owned by `cashbot-go`.

--- a/openspec/changes/expose-doc-summary-image-limit/specs/doc-summary-image-limit-config/spec.md
+++ b/openspec/changes/expose-doc-summary-image-limit/specs/doc-summary-image-limit-config/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Chart exposes document summary maxImages config
+
+The chart SHALL allow operators to configure the app's document-summary page
+image limit through the existing engine values surface.
+
+#### Scenario: Operator sets maxImages
+
+- **GIVEN** values include `engines.default.maxImages: 30`
+- **WHEN** the chart renders application `config.yaml`
+- **THEN** the rendered `engines.default` config contains `maxImages: 30`.
+
+#### Scenario: Operator omits maxImages
+
+- **GIVEN** values do not include `engines.default.maxImages`
+- **WHEN** the chart renders the default engine config
+- **THEN** the rendered config does not include `maxImages`
+- **AND** the app runtime default remains responsible for the default limit.
+
+### Requirement: Schema permits maxImages
+
+The chart SHALL accept `engines.default.maxImages` under strict values schema
+validation.
+
+#### Scenario: Helm validates values with maxImages
+
+- **GIVEN** values include `engines.default.maxImages`
+- **WHEN** Helm validates the chart values schema
+- **THEN** validation succeeds.
+
+#### Scenario: Helm rejects non-positive maxImages
+
+- **GIVEN** values include `engines.default.maxImages: 0`
+- **WHEN** Helm validates the chart values schema
+- **THEN** validation fails because maxImages must be greater than or equal to 1.
+
+### Requirement: Config exposure does not change deployment topology
+
+The chart SHALL expose the app config without changing Kubernetes resources.
+
+#### Scenario: Chart renders with maxImages
+
+- **WHEN** the chart renders with `engines.default.maxImages`
+- **THEN** no new pod, service, queue, PVC, RBAC resource, HPA, or stateful
+  resource is created for this feature.
+
+### Requirement: Runtime fix remains owned by cashbot-go
+
+The chart SHALL not claim to enforce image limits by itself.
+
+#### Scenario: Chart renders maxImages before compatible app image is deployed
+
+- **GIVEN** the chart renders `engines.default.maxImages`
+- **AND** the deployed app image does not consume that config key
+- **WHEN** a long document is summarized
+- **THEN** the chart alone is not considered a complete fix for FRA-76.

--- a/openspec/changes/expose-doc-summary-image-limit/tasks.md
+++ b/openspec/changes/expose-doc-summary-image-limit/tasks.md
@@ -1,0 +1,60 @@
+# Expose Document Summary Image Limit Tasks
+
+## 1. Discovery
+
+- [x] Re-read `AGENTS.md` and `openspec/config.yaml`.
+- [x] Re-read GroundX Studio Harness on-prem values references.
+- [x] Re-read the `cashbot-go` OpenSpec change
+      `limit-doc-summary-page-images`.
+- [x] Confirm the target app config key is `engines.default.maxImages`.
+- [x] Confirm current chart rendering omits `maxImages`.
+
+### Review Checkpoint 1
+
+- [x] Confirm this chart change is config exposure only.
+- [x] Confirm no Kubernetes workload shape or stateful resource changes are
+      needed.
+
+## 2. Update Source Chart
+
+- [x] Add `maxImages` to `src/groundx/values.schema.json` under
+      `engines.default`.
+- [x] Render `maxImages` in
+      `src/groundx/templates/resources/config-yaml.yaml` when present.
+- [x] Do not add a chart default; the app runtime owns the default of 30.
+- [x] Add or update values comments/examples only if the repo has a nearby
+      pattern for engine field documentation.
+
+### Review Checkpoint 2
+
+- [x] Confirm schema validation accepts the new field.
+- [x] Confirm rendered app `config.yaml` contains `maxImages`.
+
+## 3. Mirror Published Chart Files
+
+- [x] Mirror the same source chart changes into `helm/`.
+- [x] Do not hand-edit generated snapshot files.
+- [x] Review `src/groundx` versus `helm/` for accidental drift.
+
+### Review Checkpoint 3
+
+- [x] Confirm `helm/` is synced for the changed files.
+- [x] Confirm existing unrelated dirty `Chart.yaml` changes were not modified.
+
+## 4. Validate
+
+- [x] Run `helm lint src/groundx`.
+- [x] Run `helm template src/groundx -f src/groundx/values/minikube/values.yaml`.
+- [x] Run `helm unittest src/groundx`.
+- [x] Run `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate --all --strict --json`.
+- [x] Run `git diff --check`.
+- [x] If snapshots change, regenerate with `helm unittest -u src/groundx`.
+- [ ] Include command outputs in the final implementation handoff.
+
+## 5. Rollout Notes
+
+- [x] State that this chart change requires a compatible `cashbot-go` image to
+      affect runtime behavior.
+- [ ] Roll out to non-production self-hosted environment before production.
+- [ ] Confirm running config includes `engines.default.maxImages`.
+- [ ] Confirm app logs show selected image count for a long document.

--- a/src/groundx/templates/resources/config-yaml.yaml
+++ b/src/groundx/templates/resources/config-yaml.yaml
@@ -174,6 +174,9 @@ data:
         {{- if hasKey $e "baseUrl" }}
         baseURL: {{ get $e "baseUrl" }}
         {{- end }}
+        {{- if hasKey $e "maxImages" }}
+        maxImages: {{ get $e "maxImages" }}
+        {{- end }}
         {{- if hasKey $e "maxInputTokens" }}
         maxInputTokens: {{ get $e "maxInputTokens" }}
         {{- end }}

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -96,6 +96,7 @@
             "baseUrl": { "type": "string" },
             "dataType": { "type": "string" },
             "engineId": { "type": "string" },
+            "maxImages": { "type": "integer", "minimum": 1 },
             "maxInputTokens": { "type": "integer" },
             "maxOutputTokens": { "type": "integer" },
             "maxRequests": { "type": "integer" },


### PR DESCRIPTION
## Summary
- Exposes `engines.default.maxImages` in `config.yaml` rendering for source and packaged chart templates.
- Adds Helm schema validation requiring `maxImages` to be a positive integer when set.
- Adds OpenSpec coverage for the configurable document-summary image cap.

## Base
- Targets `0.2.7`, not `main`.

## Validation
- `helm lint src/groundx`
- `helm template src/groundx -f src/groundx/values/minikube/values.yaml`
- `helm lint src/groundx --set engines.default.engineId=test-engine --set engines.default.maxImages=0` failed as expected with `engines.default.maxImages: Must be greater than or equal to 1`
- `helm template src/groundx --show-only templates/resources/config-yaml.yaml --set engines.default.engineId=test-engine --set engines.default.maxImages=30`
- `helm template helm --show-only templates/resources/config-yaml.yaml --set engines.default.engineId=test-engine --set engines.default.maxImages=30`
- `helm lint helm`
- `helm unittest src/groundx`
- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate expose-doc-summary-image-limit --strict --json`
- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate --all --strict --json`
- `git diff --check`

## Notes
- Runtime effect requires an app image containing the paired cashbot-go change.