### PR TITLE
Allow null maxImages to use default

### DIFF
--- a/.build/bin/validate-helm.sh
+++ b/.build/bin/validate-helm.sh
@@ -80,6 +80,44 @@ for chart in src/groundx helm; do
   expect_helm_template_failure "${chart}" "maxImagePayloadBytes" --set extract.agent.maxImagePayloadBytes=0
 done
 
+echo "==> Verifying engine maxImages schema validation"
+expect_helm_lint_failure() {
+  local chart="$1"
+  local expected_description="$2"
+  local expected_regex="$3"
+  shift 3
+
+  local output
+  local status
+  set +e
+  output="$(helm lint "${chart}" --set engines.default.engineId=test-engine "$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "${status}" -eq 0 ]]; then
+    echo "Expected Helm lint to fail for ${chart}: $*" >&2
+    exit 1
+  fi
+  if [[ "${output}" != *"/engines/default/maxImages"* ]]; then
+    echo "Helm lint failed for ${chart}, but did not mention engines.default.maxImages." >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  if [[ ! "${output}" =~ ${expected_regex} ]]; then
+    echo "Helm lint failed for ${chart}, but did not mention ${expected_description}." >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+}
+
+for chart in src/groundx helm; do
+  helm lint "${chart}" --set engines.default.engineId=test-engine --set-json engines.default.maxImages=null >/dev/null
+  helm lint "${chart}" --set engines.default.engineId=test-engine --set engines.default.maxImages=30 >/dev/null
+  expect_helm_lint_failure "${chart}" "a minimum-value failure" "greater than or equal to 1|minimum: got -?[0-9]+, want 1" --set engines.default.maxImages=0
+  expect_helm_lint_failure "${chart}" "a minimum-value failure" "greater than or equal to 1|minimum: got -?[0-9]+, want 1" --set engines.default.maxImages=-1
+  expect_helm_lint_failure "${chart}" "an invalid-type failure" "Invalid type|Expected:.*integer|got string, want null or integer" --set engines.default.maxImages=many
+done
+
 echo "==> Verifying Helm snapshots did not silently drop empty renders"
 python .build/tests/test_verify_helm_snapshots.py
 python .build/bin/verify-helm-snapshots.py

--- a/helm/templates/resources/config-yaml.yaml
+++ b/helm/templates/resources/config-yaml.yaml
@@ -174,7 +174,7 @@ data:
         {{- if hasKey $e "baseUrl" }}
         baseURL: {{ get $e "baseUrl" }}
         {{- end }}
-        {{- if hasKey $e "maxImages" }}
+        {{- if and (hasKey $e "maxImages") (ne (get $e "maxImages") nil) }}
         maxImages: {{ get $e "maxImages" }}
         {{- end }}
         {{- if hasKey $e "maxInputTokens" }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -96,7 +96,7 @@
             "baseUrl": { "type": "string" },
             "dataType": { "type": "string" },
             "engineId": { "type": "string" },
-            "maxImages": { "type": "integer", "minimum": 1 },
+            "maxImages": { "type": ["integer", "null"], "minimum": 1 },
             "maxInputTokens": { "type": "integer" },
             "maxOutputTokens": { "type": "integer" },
             "maxRequests": { "type": "integer" },

--- a/openspec/changes/expose-doc-summary-image-limit/design.md
+++ b/openspec/changes/expose-doc-summary-image-limit/design.md
@@ -55,9 +55,11 @@ engines:
 
 in the application `config.yaml` engine entry.
 
-When operators provide `maxImages`, preserve and render their supplied value.
-When operators omit `maxImages`, do not render the field; the app runtime default
-of 30 remains the source of default behavior.
+When operators provide a positive integer `maxImages`, preserve and render their
+supplied value. When operators omit `maxImages` or explicitly set it to `null`,
+do not render the field; the app runtime default of 30 remains the source of
+default behavior. Reject non-positive and non-integer values during Helm schema
+validation.
 
 ## Rollout
 

--- a/openspec/changes/expose-doc-summary-image-limit/proposal.md
+++ b/openspec/changes/expose-doc-summary-image-limit/proposal.md
@@ -21,10 +21,12 @@ operators can configure it through values.
 
 - Permit positive integer `engines.default.maxImages` values in
   `src/groundx/values.schema.json`.
-- Reject non-positive configured values during Helm schema validation.
+- Permit explicit `null` and treat it the same as omission/default.
+- Reject non-positive and non-integer configured values during Helm schema
+  validation.
 - Render `maxImages` into the generated application `config.yaml` engine block
   in `src/groundx/templates/resources/config-yaml.yaml` only when an operator
-  sets it.
+  sets a positive integer.
 - Mirror source chart changes to `helm/` during implementation.
 - Update Helm snapshots if rendered output changes.
 

--- a/openspec/changes/expose-doc-summary-image-limit/specs/doc-summary-image-limit-config/spec.md
+++ b/openspec/changes/expose-doc-summary-image-limit/specs/doc-summary-image-limit-config/spec.md
@@ -18,6 +18,13 @@ image limit through the existing engine values surface.
 - **THEN** the rendered config does not include `maxImages`
 - **AND** the app runtime default remains responsible for the default limit.
 
+#### Scenario: Operator sets maxImages to null
+
+- **GIVEN** values include `engines.default.maxImages: null`
+- **WHEN** the chart renders the default engine config
+- **THEN** the rendered config does not include `maxImages`
+- **AND** the app runtime default remains responsible for the default limit.
+
 ### Requirement: Schema permits maxImages
 
 The chart SHALL accept `engines.default.maxImages` under strict values schema
@@ -29,11 +36,23 @@ validation.
 - **WHEN** Helm validates the chart values schema
 - **THEN** validation succeeds.
 
+#### Scenario: Helm validates values with null maxImages
+
+- **GIVEN** values include `engines.default.maxImages: null`
+- **WHEN** Helm validates the chart values schema
+- **THEN** validation succeeds.
+
 #### Scenario: Helm rejects non-positive maxImages
 
 - **GIVEN** values include `engines.default.maxImages: 0`
 - **WHEN** Helm validates the chart values schema
 - **THEN** validation fails because maxImages must be greater than or equal to 1.
+
+#### Scenario: Helm rejects non-integer maxImages
+
+- **GIVEN** values include `engines.default.maxImages: many`
+- **WHEN** Helm validates the chart values schema
+- **THEN** validation fails because maxImages must be an integer or null.
 
 ### Requirement: Config exposure does not change deployment topology
 

--- a/openspec/changes/expose-doc-summary-image-limit/tasks.md
+++ b/openspec/changes/expose-doc-summary-image-limit/tasks.md
@@ -20,8 +20,10 @@
 - [x] Add `maxImages` to `src/groundx/values.schema.json` under
       `engines.default`.
 - [x] Render `maxImages` in
-      `src/groundx/templates/resources/config-yaml.yaml` when present.
+      `src/groundx/templates/resources/config-yaml.yaml` when set to a
+      non-null value.
 - [x] Do not add a chart default; the app runtime owns the default of 30.
+- [x] Treat explicit `null` the same as omission/default.
 - [x] Add or update values comments/examples only if the repo has a nearby
       pattern for engine field documentation.
 
@@ -29,6 +31,9 @@
 
 - [x] Confirm schema validation accepts the new field.
 - [x] Confirm rendered app `config.yaml` contains `maxImages`.
+- [x] Confirm schema validation accepts explicit `null` and rendering omits
+      `maxImages`.
+- [x] Confirm schema validation rejects non-positive and non-integer values.
 
 ## 3. Mirror Published Chart Files
 

--- a/src/groundx/templates/resources/config-yaml.yaml
+++ b/src/groundx/templates/resources/config-yaml.yaml
@@ -174,7 +174,7 @@ data:
         {{- if hasKey $e "baseUrl" }}
         baseURL: {{ get $e "baseUrl" }}
         {{- end }}
-        {{- if hasKey $e "maxImages" }}
+        {{- if and (hasKey $e "maxImages") (ne (get $e "maxImages") nil) }}
         maxImages: {{ get $e "maxImages" }}
         {{- end }}
         {{- if hasKey $e "maxInputTokens" }}

--- a/src/groundx/tests/files/values.engine-max-images-null.yaml
+++ b/src/groundx/tests/files/values.engine-max-images-null.yaml
@@ -1,0 +1,4 @@
+engines:
+  default:
+    engineId: gpt-5.4-mini
+    maxImages: null

--- a/src/groundx/tests/files/values.engine-max-images-valid.yaml
+++ b/src/groundx/tests/files/values.engine-max-images-valid.yaml
@@ -1,0 +1,4 @@
+engines:
+  default:
+    engineId: gpt-5.4-mini
+    maxImages: 30

--- a/src/groundx/tests/resources_test.yaml
+++ b/src/groundx/tests/resources_test.yaml
@@ -134,6 +134,26 @@ tests:
       - ../values/minikube/values.yaml
     asserts:
       - matchSnapshot: {}
+  - it: "engine maxImages renders when positive"
+    templates:
+      - ../templates/resources/config-yaml.yaml
+    values:
+      - ../values.yaml
+      - ./files/values.engine-max-images-valid.yaml
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "maxImages: 30"
+  - it: "engine maxImages null is omitted"
+    templates:
+      - ../templates/resources/config-yaml.yaml
+    values:
+      - ../values.yaml
+      - ./files/values.engine-max-images-null.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "maxImages:"
   - it: "existing: resources"
     templates:
       - ../templates/resources/config-models.yaml

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -96,7 +96,7 @@
             "baseUrl": { "type": "string" },
             "dataType": { "type": "string" },
             "engineId": { "type": "string" },
-            "maxImages": { "type": "integer", "minimum": 1 },
+            "maxImages": { "type": ["integer", "null"], "minimum": 1 },
             "maxInputTokens": { "type": "integer" },
             "maxOutputTokens": { "type": "integer" },
             "maxRequests": { "type": "integer" },


### PR DESCRIPTION
Summary:
- Allow engines.default.maxImages: null in chart values schema.
- Omit maxImages from rendered config when the value is null, so cashbot uses its default.
- Add Helm unit coverage for positive render and null omission.
- Add production-gate validation for null/positive acceptance and 0/negative/string rejection across both src/groundx and helm chart surfaces.

Validation:
- helm unittest src/groundx -f tests/resources_test.yaml
- helm lint src/groundx with null and positive maxImages
- helm lint src/groundx rejects 0, -1, and string maxImages
- helm lint/template mirror chart with null and positive maxImages
- .build/bin/validate-helm.sh
- OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate expose-doc-summary-image-limit --strict --json
- git diff --check