### PR TITLE
Fix ranker inference HPA readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ without explicit human authorization.**
   templates. Sync both, every time.
 - **`upload.groundx.ai` model-weight download is HARDCODED** in inference init-containers — an
   **air-gap blocker**; weights must be mirrored for offline installs (mechanism not documented in-repo).
+- **Hosted ranker-only EKS is migration-state, not generic chart truth.** As of 2026-07-23,
+  hosted search inference is two EC2 `search-inference-*.groundx.ai` servers plus one EKS
+  `ranker-inference` pod. One EKS replica can mean one GPU node; judge HPA behavior with
+  GPU node-group scale-up and model readiness, not just pod count.
 - **The `groundx.extract` config binding is UNSCHEMATIZED.** `extract-config-py.yaml` generates Python
   that does `from groundx.extract import (AgentSettings, ContainerSettings, ContainerUploadSettings,
   GroundXSettings)` — binding to constructor signatures in the `eyelevel/extract` **image**, not this

--- a/README.md
+++ b/README.md
@@ -693,6 +693,10 @@ Every autoscaled pod scales on **two metrics**:
    - **task**: Celery task backlog (default target **10**)
    - **inference**: model request throughput (scales when requests exceed per-replica capacity)
 
+For GPU inference, HPA scale-up also depends on node readiness. If each inference
+pod uses a full GPU node, every additional replica needs both a new pod and a new
+GPU node before it can absorb traffic.
+
 ## Enabling the Custom Metrics Server
 
 The custom metrics server exposes:

--- a/helm/templates/_helpers/app/ranker-inference.tpl
+++ b/helm/templates/_helpers/app/ranker-inference.tpl
@@ -23,6 +23,12 @@ true
 {{- end -}}
 {{- end }}
 
+{{- define "groundx.ranker.inference.containerPort" -}}
+{{- $b := .Values.ranker | default dict -}}
+{{- $in := dig "inference" dict $b -}}
+{{ dig "containerPort" 8080 $in }}
+{{- end }}
+
 {{- define "groundx.ranker.inference.deviceType" -}}
 {{- $b := .Values.ranker | default dict -}}
 {{- $in := dig "inference" dict $b -}}
@@ -103,6 +109,7 @@ true
 {{- end -}}
 {{- $name := (include "groundx.ranker.inference.serviceName" .) -}}
 {{- $cld := dig "cooldown" 60 $rep -}}
+{{- $upCl := dig "upCooldown" $cld $rep -}}
 {{- $cfg := dict
   "downCooldown" (mul $cld 2)
   "enabled"      $enabled
@@ -110,7 +117,7 @@ true
   "name"         $name
   "replicas"     $rep
   "throughput"   (printf "%s:throughput" $name)
-  "upCooldown"   $cld
+  "upCooldown"   $upCl
 -}}
 {{- $cfg | toYaml -}}
 {{- end }}
@@ -197,7 +204,6 @@ true
 {{- $cfg := dict
   "baseName"       ($svc)
   "cache"          (include "groundx.ranker.cache.settings" . | fromYaml)
-  "celery"         ("ranker.celery.appSearch")
   "cfg"            (printf "%s-config-py-map" $svc)
   "image"          (include "groundx.ranker.inference.image" .)
   "mapPrefix"      ("ranker")
@@ -205,6 +211,7 @@ true
   "modelVersion"   ("model")
   "name"           (include "groundx.ranker.inference.serviceName" .)
   "node"           (include "groundx.ranker.inference.node" .)
+  "port"           (include "groundx.ranker.inference.containerPort" .)
   "pull"           (include "groundx.ranker.inference.imagePullPolicy" .)
   "pvc"            (include "groundx.ranker.inference.pvc" . | fromYaml)
   "replicas"       ($rep)

--- a/helm/templates/resources/ranker-supervisord-conf.yaml
+++ b/helm/templates/resources/ranker-supervisord-conf.yaml
@@ -32,4 +32,28 @@ data:
     stderr_logfile=/dev/stderr
     stderr_logfile_maxbytes=0
     {{ end }}
+
+    [program:celery_monitor]
+    command=python /workspace/ranker_monitor.py
+    environment=
+      LOCAL="0",
+      PYTHONUNBUFFERED="1"
+    autostart=true
+    autorestart=true
+    stdout_logfile=/dev/stdout
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/stderr
+    stderr_logfile_maxbytes=0
+
+    [program:celery_health]
+    command=python /workspace/ranker_health.py
+    environment=
+      LOCAL="0",
+      PYTHONUNBUFFERED="1"
+    autostart=true
+    autorestart=true
+    stdout_logfile=/dev/stdout
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/stderr
+    stderr_logfile_maxbytes=0
 {{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1263,9 +1263,15 @@
             "replicas": {
               "type": "object",
               "properties": {
+                "cooldown": { "type": "integer" },
                 "desired": { "type": "integer" },
+                "hpa": { "type": "boolean" },
                 "max": { "type": "integer" },
-                "min": { "type": "integer" }
+                "min": { "type": "integer" },
+                "target": { "type": "number" },
+                "threshold": { "type": "number" },
+                "throughput": { "type": "number" },
+                "upCooldown": { "type": "integer" }
               },
               "required": ["desired"],
               "additionalProperties": false

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/design.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/design.md
@@ -1,0 +1,119 @@
+# Fix Ranker Inference HPA Readiness Design
+
+## Goals
+
+- Make ranker readiness behave like layout and summary readiness.
+- Keep ranker worker-capacity records alive during idle periods.
+- Start adding ranker capacity before the current pod is saturated.
+- Keep one always-on ranker replica after traffic subsides.
+
+## Non-Goals
+
+- No GPU node or Cluster Autoscaler changes.
+- No search behavior changes.
+- No secret changes.
+- No deployment.
+
+## Current Failure
+
+`ai-server` records each ranker worker as available or busy and exposes
+`/health`. The chart still marks ranker inference with a Celery process setting,
+which selects process-based probes in the shared inference template. Kubernetes
+therefore never polls `/health`.
+
+Idle worker records expire from Redis after five minutes. Once they expire, the
+external HPA metric no longer has an accurate ranker-capacity baseline.
+
+The hosted HPA also uses the shared 75-second scale-up stabilization window and
+a target of `0.6`, which reacts too late for this service.
+
+## Design
+
+### AI-server health contract
+
+Ranker workers report available status at startup and restore it after every
+request, including failures. The ranker health server reports:
+
+- `/alive`: the health process is running;
+- `/health`: all configured ranker workers are registered.
+
+Kubernetes polling of `/health` refreshes worker records while the service is
+idle.
+
+### Helm probe parity
+
+Add a ranker inference container-port helper with default port `8080`. Include
+that port in ranker inference settings and remove the Celery marker that selects
+process probes.
+
+The shared inference template will then render the same HTTP readiness and
+liveness probes used by layout and summary inference.
+
+### Hosted HPA settings
+
+Use:
+
+```yaml
+ranker:
+  inference:
+    replicas:
+      desired: 1
+      min: 1
+      max: 4
+      target: 0.4
+      threshold: 60000
+      throughput: 60000
+      upCooldown: 15
+```
+
+The target controls worker-occupancy scaling. The throughput values remain the
+initial sizing floor. `upCooldown` shortens ranker scale-up only. The inherited
+75-second cooldown still produces a 150-second scale-down stabilization window.
+
+## Source Evidence
+
+- `ai-server/ranker/tasks/inference.py`
+- `ai-server/ranker_monitor.py`
+- `ai-server/ranker_health.py`
+- `ai-server/constants.py`
+- `groundx-on-prem/src/groundx/templates/_helpers/app/ranker-inference.tpl`
+- `groundx-on-prem/src/groundx/templates/app/inference.yaml`
+- `groundx-on-prem/src/groundx/templates/resources/hpa.yaml`
+- `cashbot-go/pkg/operator/metrics.go`
+
+## Rollout
+
+Implementation stops before deployment.
+
+After separate approval:
+
+1. Build and publish the ranker image.
+2. Deploy to a non-production environment with one ranker replica.
+3. Confirm `/alive` and `/health` pass and the external metric retains its idle
+   capacity baseline for more than five minutes.
+4. Apply a controlled load and confirm HPA requests a second replica before the
+   first is saturated.
+5. Confirm scale-down returns to one replica.
+6. Promote to production in a separate operation.
+
+Because each new ranker pod requires a GPU node, node startup remains a separate
+capacity risk. This change improves the HPA signal but does not change node
+provisioning.
+
+## Rollback
+
+Deploy the previous image and chart, then restore the prior HPA target and
+cooldown. No data rollback is required.
+
+## Validation
+
+- focused Helm test fails before the probe fix and passes after it;
+- `python -m unittest ranker.tasks.test_inference_status`;
+- `python -m py_compile` for changed ranker Python modules;
+- `helm lint src/groundx -f values.ranker-only-eks.yaml`;
+- `helm lint helm -f values.ranker-only-eks.yaml`;
+- `helm unittest src/groundx`;
+- hosted values render review for ranker probes and HPA;
+- source/mirror comparison;
+- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate --all --strict --json`;
+- `git diff --check`.

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/proposal.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/proposal.md
@@ -1,0 +1,76 @@
+# Fix Ranker Inference HPA Readiness
+
+## Why
+
+The ranker image now publishes worker-capacity metrics, but the Helm chart still
+uses a process check for readiness. After an idle period, worker records expire
+and the HPA loses the capacity signal it needs to scale before the current pod is
+saturated.
+
+Ranker inference should use the same HTTP health contract as layout and summary
+inference. Hosted HPA settings should also begin scaling earlier while keeping
+one always-on replica.
+
+## Blast Radius
+
+- Changes ranker inference readiness and liveness probes from process checks to
+  the existing HTTP health server.
+- Changes hosted ranker HPA scale-up sensitivity and timing.
+- Affects ranker inference rollouts in environments that adopt these chart and
+  image changes.
+- Does not change search request routing, ranker model behavior, GPU node type,
+  node groups, Cluster Autoscaler, secrets, or stateful resources.
+
+The chart currently uses `Recreate` for the hosted ranker deployment, so a
+deployment can briefly remove EKS ranker capacity. This change will not be
+deployed as part of implementation.
+
+## What Changes
+
+- Make ranker inference expose and use HTTP `/alive` and `/health` probes,
+  matching layout and summary inference.
+- Keep `/health` unavailable until the configured ranker workers have
+  registered, so polling preserves their capacity records.
+- Keep hosted ranker HPA minimum at 1 and maximum at 4.
+- Set the hosted ranker HPA target to `0.4`.
+- Set the hosted ranker scale-up cooldown to 15 seconds.
+- Keep the existing ranker throughput sizing values unchanged.
+- Add focused AI-server and Helm tests.
+- Mirror chart source changes into `helm/`.
+
+## Out Of Scope
+
+- Deploying these changes.
+- Changing GPU instance type, node group size, node labels, or scheduling.
+- Changing or upgrading Cluster Autoscaler.
+- Changing search fanout, OpenSearch candidates, model code, or API routing.
+- Changing secrets.
+- Changing the hosted ranker `Recreate` update strategy.
+
+## Affected Environments
+
+- The tracked chart change applies to environments that enable ranker
+  inference.
+- The HPA tuning applies to the hosted EKS values file only.
+- Dev, staging, and production are unaffected until an operator deploys the
+  matching chart and ranker image.
+
+There is no data or stateful resource impact.
+
+## Rollback / Rollforward
+
+Rollback:
+
+- deploy the previous chart and ranker image;
+- restore the previous hosted HPA target and cooldown.
+
+Rollforward:
+
+- build the ranker image with worker health reporting;
+- render and inspect the chart;
+- deploy to a non-production environment and confirm health and HPA metrics;
+- promote separately after an explicit production approval.
+
+## Open Design Questions
+
+None. The approved scope is limited to ranker health polling and HPA behavior.

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/specs/ranker-inference-autoscaling/spec.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/specs/ranker-inference-autoscaling/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Ranker inference uses worker-aware HTTP health probes
+
+The chart SHALL use the ranker health server for Kubernetes liveness and
+readiness, matching layout and summary inference.
+
+#### Scenario: Ranker inference is rendered
+
+- **GIVEN** ranker inference is enabled
+- **WHEN** the chart renders the ranker Deployment
+- **THEN** liveness uses HTTP `GET /alive` on port `8080`
+- **AND** readiness uses HTTP `GET /health` on port `8080`
+- **AND** ranker readiness does not use a process-name check.
+
+#### Scenario: Ranker workers are not registered
+
+- **GIVEN** fewer ranker workers are registered than the configured worker count
+- **WHEN** Kubernetes polls `/health`
+- **THEN** the endpoint reports that ranker inference is not ready.
+
+#### Scenario: Ranker workers are idle
+
+- **GIVEN** all ranker workers are registered and no requests are running
+- **WHEN** Kubernetes continues polling `/health`
+- **THEN** worker availability records remain present for the external HPA
+  metric.
+
+### Requirement: Ranker workers restore availability
+
+Each ranker worker SHALL report itself available after request handling ends.
+
+#### Scenario: Ranker inference succeeds
+
+- **GIVEN** a ranker worker accepts a valid request
+- **WHEN** inference completes
+- **THEN** the worker reports itself available.
+
+#### Scenario: Ranker inference fails
+
+- **GIVEN** a ranker worker accepts a request
+- **WHEN** validation or inference fails
+- **THEN** the worker reports itself available before the failure returns.
+
+### Requirement: Hosted ranker HPA scales earlier
+
+The hosted ranker configuration SHALL preserve one always-on replica and begin
+scale-up before the current replica is saturated.
+
+#### Scenario: Hosted ranker HPA is rendered
+
+- **GIVEN** the hosted EKS ranker values file
+- **WHEN** the chart renders the ranker HPA
+- **THEN** minimum replicas is `1`
+- **AND** maximum replicas is `4`
+- **AND** each ranker external metric target is `0.4`
+- **AND** scale-up stabilization is `15` seconds
+- **AND** scale-down stabilization remains `150` seconds.
+
+#### Scenario: Hosted ranker traffic is idle
+
+- **GIVEN** traffic has subsided and scale-down completes
+- **WHEN** the HPA reaches its configured minimum
+- **THEN** one ranker inference replica remains running.
+
+### Requirement: Node provisioning remains unchanged
+
+This change SHALL not modify GPU node or Cluster Autoscaler configuration.
+
+#### Scenario: The change is implemented
+
+- **WHEN** the implementation diff is reviewed
+- **THEN** no node type, node group, scheduling label, taint, or Cluster
+  Autoscaler setting has changed
+- **AND** no deployment has been performed.

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/tasks.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/tasks.md
@@ -1,0 +1,61 @@
+# Fix Ranker Inference HPA Readiness Tasks
+
+## 1. Confirm Scope
+
+- [x] Re-read repo instructions and OpenSpec configuration.
+- [x] Trace the external ranker metric from worker status through
+      `cashbot-go/pkg/operator/metrics.go`.
+- [x] Compare ranker inference probes with layout and summary inference.
+- [x] Confirm GPU node and Cluster Autoscaler changes are out of scope.
+- [x] Confirm implementation must stop before deployment.
+
+## 2. Add Regression Coverage
+
+- [x] Add a Helm test that expects ranker HTTP `/alive` and `/health` probes.
+- [x] Assert hosted HPA values render as min 1, max 4, target `0.4`, and
+      15-second scale-up stabilization.
+- [x] Run the focused Helm test and confirm it fails before the template fix.
+
+## 3. Implement Probe And HPA Fix
+
+- [x] Add ranker inference port `8080` to the source chart helper.
+- [x] Select the shared HTTP probe path for ranker inference.
+- [x] Mirror the changed chart helper into `helm/`.
+- [x] Set hosted ranker HPA target to `0.4` and scale-up cooldown to 15 seconds.
+- [x] Keep hosted ranker min 1, max 4, threshold 60000, and throughput 60000.
+- [x] Leave secrets, node settings, and update strategy unchanged.
+
+## 4. Verify Worker State
+
+- [x] Test that a malformed ranker request restores worker availability.
+- [x] Test that a ranker inference exception restores worker availability.
+- [x] Confirm the ranker health process uses the same worker count as the
+      ranker worker process.
+
+## 5. Validate
+
+- [x] Regenerate Helm snapshots with `helm unittest -u src/groundx`.
+- [x] Run all `ai-server` ranker tests and Python compile checks.
+- [x] Run `helm lint` for source and mirror charts with hosted values.
+- [x] Run the full Helm unit test suite.
+- [x] Render hosted ranker resources and inspect probes, HPA metrics, and
+      scale-up behavior.
+- [x] Confirm changed source and mirror files match.
+- [x] Validate OpenSpec strictly.
+- [x] Run `git diff --check` in both repos.
+
+## 6. Review And Handoff
+
+- [x] Run an independent adversarial review against this OpenSpec change.
+- [x] Normalize Celery task hostnames to the worker names used by health.
+- [x] Keep 15-second scale-up separate from 150-second scale-down.
+- [x] Resolve all in-scope findings.
+- [x] Report validation evidence and remaining node-provisioning risk.
+- [x] Confirm no deployment was performed.
+
+## 7. Future Rollout
+
+- [ ] Deploy to non-production after separate approval.
+- [ ] Confirm worker capacity remains visible after more than five idle minutes.
+- [ ] Confirm controlled load scales above one replica and later returns to one.
+- [ ] Obtain separate approval before production deployment.

--- a/src/groundx/templates/_helpers/app/ranker-inference.tpl
+++ b/src/groundx/templates/_helpers/app/ranker-inference.tpl
@@ -23,6 +23,12 @@ true
 {{- end -}}
 {{- end }}
 
+{{- define "groundx.ranker.inference.containerPort" -}}
+{{- $b := .Values.ranker | default dict -}}
+{{- $in := dig "inference" dict $b -}}
+{{ dig "containerPort" 8080 $in }}
+{{- end }}
+
 {{- define "groundx.ranker.inference.deviceType" -}}
 {{- $b := .Values.ranker | default dict -}}
 {{- $in := dig "inference" dict $b -}}
@@ -103,6 +109,7 @@ true
 {{- end -}}
 {{- $name := (include "groundx.ranker.inference.serviceName" .) -}}
 {{- $cld := dig "cooldown" 60 $rep -}}
+{{- $upCl := dig "upCooldown" $cld $rep -}}
 {{- $cfg := dict
   "downCooldown" (mul $cld 2)
   "enabled"      $enabled
@@ -110,7 +117,7 @@ true
   "name"         $name
   "replicas"     $rep
   "throughput"   (printf "%s:throughput" $name)
-  "upCooldown"   $cld
+  "upCooldown"   $upCl
 -}}
 {{- $cfg | toYaml -}}
 {{- end }}
@@ -197,7 +204,6 @@ true
 {{- $cfg := dict
   "baseName"       ($svc)
   "cache"          (include "groundx.ranker.cache.settings" . | fromYaml)
-  "celery"         ("ranker.celery.appSearch")
   "cfg"            (printf "%s-config-py-map" $svc)
   "image"          (include "groundx.ranker.inference.image" .)
   "mapPrefix"      ("ranker")
@@ -205,6 +211,7 @@ true
   "modelVersion"   ("model")
   "name"           (include "groundx.ranker.inference.serviceName" .)
   "node"           (include "groundx.ranker.inference.node" .)
+  "port"           (include "groundx.ranker.inference.containerPort" .)
   "pull"           (include "groundx.ranker.inference.imagePullPolicy" .)
   "pvc"            (include "groundx.ranker.inference.pvc" . | fromYaml)
   "replicas"       ($rep)

--- a/src/groundx/templates/resources/ranker-supervisord-conf.yaml
+++ b/src/groundx/templates/resources/ranker-supervisord-conf.yaml
@@ -32,4 +32,28 @@ data:
     stderr_logfile=/dev/stderr
     stderr_logfile_maxbytes=0
     {{ end }}
+
+    [program:celery_monitor]
+    command=python /workspace/ranker_monitor.py
+    environment=
+      LOCAL="0",
+      PYTHONUNBUFFERED="1"
+    autostart=true
+    autorestart=true
+    stdout_logfile=/dev/stdout
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/stderr
+    stderr_logfile_maxbytes=0
+
+    [program:celery_health]
+    command=python /workspace/ranker_health.py
+    environment=
+      LOCAL="0",
+      PYTHONUNBUFFERED="1"
+    autostart=true
+    autorestart=true
+    stdout_logfile=/dev/stdout
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/stderr
+    stderr_logfile_maxbytes=0
 {{- end }}

--- a/src/groundx/tests/__snapshot__/inference_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/inference_test.yaml.snap
@@ -290,7 +290,7 @@
             config-hash: b0c8193aca6eccd6282f680fa67313a44dd0ac24a73ea84906276482bde9c15e
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -322,23 +322,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -1075,7 +1075,7 @@
             config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -1107,23 +1107,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -1858,7 +1858,7 @@
             config-hash: d09038b15d81b45a3c91b675dba9421905acbd940eca1349b6af31098c98c043
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -1890,23 +1890,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -2642,7 +2642,7 @@
             config-hash: d09038b15d81b45a3c91b675dba9421905acbd940eca1349b6af31098c98c043
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -2674,23 +2674,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -3425,7 +3425,7 @@
             config-hash: 8e63ebfea1c0f60ac40bef43a8944a14369538ba8bb0421a10a4a0be5a804b9e
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -3457,23 +3457,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -3956,7 +3956,7 @@
             config-hash: b9925462022bebe3881e71f27efbc04bb7bfd6e0f9e2e70a62d76cfcc676d69d
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -3991,23 +3991,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -4747,7 +4747,7 @@
             config-hash: 1c478ed103e29a5ca3e1fea4246d3385551c8f60f4141a412bdd8afdfa5115ab
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -4779,23 +4779,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -5534,7 +5534,7 @@
             config-hash: b9925462022bebe3881e71f27efbc04bb7bfd6e0f9e2e70a62d76cfcc676d69d
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -5569,23 +5569,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -6041,7 +6041,7 @@
             config-hash: db12e6d22be007fc52ee601f6989646694bae2a985f615c39bcfef2d46258a3e
             config-models-hash: 06ba464c30a765382364510ccee1e65088f7d2acbc11a746b7d14d84c220dd3b
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: a16c30167d8dc53d033246f4104113e03f8726f3a97dc8a7bb0af9a936a58c80
+            supervisord-hash: 8464ec25dcc7b52084949079db8004277a72b0c6d49235247cb01f7d8fde7595
           labels:
             app: myapp-inference
         spec:
@@ -6073,23 +6073,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: myapp-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -6744,7 +6744,7 @@
           annotations:
             config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -6776,23 +6776,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -7375,7 +7375,7 @@
           annotations:
             config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -7407,23 +7407,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1
@@ -7992,7 +7992,7 @@
           annotations:
             config-hash: 8c8d3d4f45d68a2a23457d8db11374d236b3e1b2f01730bbb2426421e92af4e5
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -8024,23 +8024,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: Always
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1

--- a/src/groundx/tests/__snapshot__/ranker_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/ranker_test.yaml.snap
@@ -186,7 +186,7 @@
             config-hash: 9e90962567931cc0f6532dd90edf2830e7b83094c61024b09c3152278b67f4ba
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
-            supervisord-hash: c3de8d835a18146d0f59120a18513f20056efbb1cda896213ca789277d88a71b
+            supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
             app: ranker-inference
         spec:
@@ -218,23 +218,23 @@
               image: public.ecr.aws/c9r4x6y5/eyelevel/ranker-inference:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                failureThreshold: 10
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 8
+                httpGet:
+                  path: /alive
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               name: ranker-inference
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               readinessProbe:
-                exec:
-                  command:
-                    - /bin/sh
-                    - -c
-                    - ps aux | grep 'ranker.celery.appSearch' | grep -v grep || exit 1
-                initialDelaySeconds: 60
-                periodSeconds: 30
+                failureThreshold: 30
+                httpGet:
+                  path: /health
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 15
               resources:
                 limits:
                   nvidia.com/gpu: 1

--- a/src/groundx/tests/__snapshot__/resources_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/resources_test.yaml.snap
@@ -851,6 +851,31 @@
         stdout_logfile_maxbytes=0
         stderr_logfile=/dev/stderr
         stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
     kind: ConfigMap
     metadata:
       labels:
@@ -2023,6 +2048,31 @@
         stdout_logfile_maxbytes=0
         stderr_logfile=/dev/stderr
         stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
     kind: ConfigMap
     metadata:
       labels:
@@ -3013,6 +3063,31 @@
         stdout_logfile_maxbytes=0
         stderr_logfile=/dev/stderr
         stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
     kind: ConfigMap
     metadata:
       labels:
@@ -3966,6 +4041,31 @@
         command=celery -A ranker.celery.appSearch worker -n %(ENV_POD_NAME)s-w14 --loglevel=INFO --concurrency=1 --queues=inference_queue
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w14",
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
           LOCAL="0",
           PYTHONUNBUFFERED="1"
         autostart=true
@@ -4940,6 +5040,31 @@
         command=celery -A ranker.celery.appSearch worker -n %(ENV_POD_NAME)s-w14 --loglevel=INFO --concurrency=1 --queues=inference_queue
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w14",
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
           LOCAL="0",
           PYTHONUNBUFFERED="1"
         autostart=true
@@ -5975,6 +6100,31 @@
         command=celery -A ranker.celery.appSearch worker -n %(ENV_POD_NAME)s-w14 --loglevel=INFO --concurrency=1 --queues=inference_queue
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w14",
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
           LOCAL="0",
           PYTHONUNBUFFERED="1"
         autostart=true
@@ -7188,6 +7338,31 @@
         stdout_logfile_maxbytes=0
         stderr_logfile=/dev/stderr
         stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
     kind: ConfigMap
     metadata:
       labels:
@@ -8321,6 +8496,31 @@
         stdout_logfile_maxbytes=0
         stderr_logfile=/dev/stderr
         stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
     kind: ConfigMap
     metadata:
       labels:
@@ -9149,6 +9349,31 @@
         command=celery -A ranker.celery.appSearch worker -n %(ENV_POD_NAME)s-w4 --loglevel=INFO --concurrency=2 --queues=my-queue
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w4",
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
           LOCAL="0",
           PYTHONUNBUFFERED="1"
         autostart=true
@@ -10117,6 +10342,31 @@
         stdout_logfile_maxbytes=0
         stderr_logfile=/dev/stderr
         stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
     kind: ConfigMap
     metadata:
       labels:
@@ -11058,6 +11308,31 @@
         command=celery -A ranker.celery.appSearch worker -n %(ENV_POD_NAME)s-w14 --loglevel=INFO --concurrency=1 --queues=inference_queue
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w14",
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
           LOCAL="0",
           PYTHONUNBUFFERED="1"
         autostart=true
@@ -12208,6 +12483,31 @@
         command=celery -A ranker.celery.appSearch worker -n %(ENV_POD_NAME)s-w14 --loglevel=INFO --concurrency=1 --queues=inference_queue
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w14",
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+
+        [program:celery_monitor]
+        command=python /workspace/ranker_monitor.py
+        environment=
+          LOCAL="0",
+          PYTHONUNBUFFERED="1"
+        autostart=true
+        autorestart=true
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        stderr_logfile=/dev/stderr
+        stderr_logfile_maxbytes=0
+
+        [program:celery_health]
+        command=python /workspace/ranker_health.py
+        environment=
           LOCAL="0",
           PYTHONUNBUFFERED="1"
         autostart=true

--- a/src/groundx/tests/ranker_test.yaml
+++ b/src/groundx/tests/ranker_test.yaml
@@ -4,6 +4,68 @@ chart:
   version: 0.1.0
 
 tests:
+  - it: "ranker inference uses worker-aware HTTP probes"
+    templates:
+      - ../templates/app/inference.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      ranker.inference.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: ranker-inference
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /alive
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8080
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.exec
+  - it: "ranker inference HPA scales early and keeps one replica"
+    templates:
+      - ../templates/resources/hpa.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      ranker.inference.enabled: true
+      ranker.inference.replicas.hpa: true
+      ranker.inference.replicas.desired: 1
+      ranker.inference.replicas.min: 1
+      ranker.inference.replicas.max: 4
+      ranker.inference.replicas.target: 0.4
+      ranker.inference.replicas.threshold: 60000
+      ranker.inference.replicas.throughput: 60000
+      ranker.inference.replicas.upCooldown: 15
+    documentSelector:
+      path: metadata.name
+      value: ranker-inference-hpa
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 4
+      - equal:
+          path: spec.metrics[0].external.target.value
+          value: 0.4
+      - equal:
+          path: spec.metrics[1].external.target.value
+          value: 0.4
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 15
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 150
   - it: "cache override: ranker config"
     templates:
       - ../templates/resources/ranker-config-py.yaml

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1263,9 +1263,15 @@
             "replicas": {
               "type": "object",
               "properties": {
+                "cooldown": { "type": "integer" },
                 "desired": { "type": "integer" },
+                "hpa": { "type": "boolean" },
                 "max": { "type": "integer" },
-                "min": { "type": "integer" }
+                "min": { "type": "integer" },
+                "target": { "type": "number" },
+                "threshold": { "type": "number" },
+                "throughput": { "type": "number" },
+                "upCooldown": { "type": "integer" }
               },
               "required": ["desired"],
               "additionalProperties": false


### PR DESCRIPTION
## Summary
- Add the OpenSpec plan for ranker inference HPA readiness.
- Switch ranker inference to worker-aware HTTP `/alive` and `/health` probes, matching layout and summary inference.
- Add ranker supervisor health/monitor programs, schema support, and Helm tests for the HPA/probe behavior.
- Keep hosted ranker min `1`, max `4`, threshold/throughput `60000`; lower the HPA target to `0.4` and scale-up stabilization to `15s`.

## Why
Ranker autoscaling needs Kubernetes to poll the worker health endpoint so idle worker records stay current and the external metric reflects real capacity before the pod saturates.

## Rollout note
Depends on the matching ranker image from `EyeLevel-ai/ai-server#38`. No node, Cluster Autoscaler, secret, search routing, or deployment changes are included.

## Validation
- `.build/bin/validate-helm.sh`
- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate --all --strict --json`
- source/mirror `cmp` for the changed helper, supervisor config, and schema
- PR diff checked for deleted snapshot labels
- `git diff --check`

No deployment performed.