### PR TITLE
Taint GPU node groups and align NVIDIA operator values

### DIFF
--- a/helm/values/chainguard/values.nvidia.yaml
+++ b/helm/values/chainguard/values.nvidia.yaml
@@ -1,2 +1,32 @@
 operator:
   runtimeClass: nvidia-container-runtime
+
+dcgmExporter:
+  enabled: false
+
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: eyelevel_node
+      operator: Exists
+      effect: NoSchedule
+
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: eyelevel_node
+        operator: Exists
+        effect: NoSchedule

--- a/helm/values/nvidia/values.aks.yaml
+++ b/helm/values/nvidia/values.aks.yaml
@@ -1,2 +1,32 @@
 operator:
   runtimeClass: nvidia-container-runtime
+
+dcgmExporter:
+  enabled: false
+
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: eyelevel_node
+      operator: Exists
+      effect: NoSchedule
+
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: eyelevel_node
+        operator: Exists
+        effect: NoSchedule

--- a/helm/values/nvidia/values.yaml
+++ b/helm/values/nvidia/values.yaml
@@ -1,2 +1,32 @@
 operator:
   runtimeClass: nvidia
+
+dcgmExporter:
+  enabled: false
+
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: eyelevel_node
+      operator: Exists
+      effect: NoSchedule
+
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: eyelevel_node
+        operator: Exists
+        effect: NoSchedule

--- a/src/groundx/values/chainguard/values.nvidia.yaml
+++ b/src/groundx/values/chainguard/values.nvidia.yaml
@@ -1,2 +1,32 @@
 operator:
   runtimeClass: nvidia-container-runtime
+
+dcgmExporter:
+  enabled: false
+
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: eyelevel_node
+      operator: Exists
+      effect: NoSchedule
+
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: eyelevel_node
+        operator: Exists
+        effect: NoSchedule

--- a/src/groundx/values/nvidia/values.aks.yaml
+++ b/src/groundx/values/nvidia/values.aks.yaml
@@ -1,2 +1,32 @@
 operator:
   runtimeClass: nvidia-container-runtime
+
+dcgmExporter:
+  enabled: false
+
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: eyelevel_node
+      operator: Exists
+      effect: NoSchedule
+
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: eyelevel_node
+        operator: Exists
+        effect: NoSchedule

--- a/src/groundx/values/nvidia/values.yaml
+++ b/src/groundx/values/nvidia/values.yaml
@@ -1,2 +1,32 @@
 operator:
   runtimeClass: nvidia
+
+dcgmExporter:
+  enabled: false
+
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: eyelevel_node
+      operator: Exists
+      effect: NoSchedule
+
+node-feature-discovery:
+  worker:
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: ""
+        effect: NoSchedule
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: eyelevel_node
+        operator: Exists
+        effect: NoSchedule

--- a/terraform/aws/eks/eks.tf
+++ b/terraform/aws/eks/eks.tf
@@ -199,6 +199,14 @@ locals {
           "eyelevel_node"                                   = local.gpu_layout_label
         }
 
+        taints                                              = {
+          eyelevel_node                                      = {
+            key                                             = "eyelevel_node"
+            value                                           = local.gpu_layout_label
+            effect                                          = "NO_SCHEDULE"
+          }
+        }
+
         tags                                                = {
           Environment                                       = var.environment.stage
           Name                                              = local.gpu_layout_label
@@ -238,6 +246,14 @@ locals {
 
         labels                                              = {
           "eyelevel_node"                                   = local.gpu_summary_label
+        }
+
+        taints                                              = {
+          eyelevel_node                                      = {
+            key                                             = "eyelevel_node"
+            value                                           = local.gpu_summary_label
+            effect                                          = "NO_SCHEDULE"
+          }
         }
 
         tags                                                = {
@@ -281,6 +297,14 @@ locals {
 
         labels                                              = {
           "eyelevel_node"                                   = local.gpu_ranker_label
+        }
+
+        taints                                              = {
+          eyelevel_node                                      = {
+            key                                             = "eyelevel_node"
+            value                                           = local.gpu_ranker_label
+            effect                                          = "NO_SCHEDULE"
+          }
         }
 
         tags                                                = {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -279,7 +279,7 @@ variable "nodes" {
           volume_size           = 75
           volume_type           = "gp2"
         }
-        instance_types          = ["g4dn.2xlarge"]
+        instance_types          = ["g6e.xlarge"]
         max_size                = 10
         min_size                = 1
       }

--- a/terraform/groundx-operator/README.md
+++ b/terraform/groundx-operator/README.md
@@ -339,8 +339,7 @@ The default resource configurations for AWS EC2 are specified [here](#total-reco
 1x m6a.xlarge
 4x t3a.medium
 1x g4dn.xlarge
-1x g4dn.2xlarge
-1x g6e.xlarge
+2x g6e.xlarge
 ~300 GB gp2
 ```
 

--- a/terraform/groundx-operator/operator/init/add/nvidia.tf
+++ b/terraform/groundx-operator/operator/init/add/nvidia.tf
@@ -41,11 +41,11 @@ locals {
 resource "helm_release" "gpu_operator" {
   count = (var.cluster.has_nvidia || local.is_openshift) ? 0 : 1
 
-  name             = var.cluster_internal.nvidia.name
+  name = var.cluster_internal.nvidia.name
 
-  repository       = var.cluster_internal.nvidia.chart.repository
-  chart            = var.cluster_internal.nvidia.chart.name
-  version          = var.cluster_internal.nvidia.chart.version
+  repository = var.cluster_internal.nvidia.chart.repository
+  chart      = var.cluster_internal.nvidia.chart.name
+  version    = var.cluster_internal.nvidia.chart.version
 
   namespace        = var.cluster_internal.nvidia.namespace
   create_namespace = true
@@ -68,8 +68,11 @@ resource "helm_release" "gpu_operator" {
         runtimeClass = "nvidia-container-runtime"
       }
     })
-  ] : [
+    ] : [
     yamlencode({
+      dcgmExporter = {
+        enabled = var.cluster.type != "eks"
+      }
       daemonsets = {
         tolerations = local.nvidia_operator_daemonset_tolerations
       }

--- a/terraform/groundx-operator/operator/init/add/nvidia.tf
+++ b/terraform/groundx-operator/operator/init/add/nvidia.tf
@@ -1,3 +1,43 @@
+locals {
+  nvidia_operator_daemonset_tolerations = [
+    {
+      key      = "nvidia.com/gpu"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    },
+    {
+      key      = "eyelevel_node"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    }
+  ]
+
+  nvidia_operator_nfd_worker_tolerations = [
+    {
+      key      = "node-role.kubernetes.io/master"
+      operator = "Equal"
+      value    = ""
+      effect   = "NoSchedule"
+    },
+    {
+      key      = "node-role.kubernetes.io/control-plane"
+      operator = "Equal"
+      value    = ""
+      effect   = "NoSchedule"
+    },
+    {
+      key      = "nvidia.com/gpu"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    },
+    {
+      key      = "eyelevel_node"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    }
+  ]
+}
+
 resource "helm_release" "gpu_operator" {
   count = (var.cluster.has_nvidia || local.is_openshift) ? 0 : 1
 
@@ -16,12 +56,28 @@ resource "helm_release" "gpu_operator" {
 
   values = var.cluster.type == "aks" ? [
     yamlencode({
+      daemonsets = {
+        tolerations = local.nvidia_operator_daemonset_tolerations
+      }
+      "node-feature-discovery" = {
+        worker = {
+          tolerations = local.nvidia_operator_nfd_worker_tolerations
+        }
+      }
       operator = {
         runtimeClass = "nvidia-container-runtime"
       }
     })
   ] : [
     yamlencode({
+      daemonsets = {
+        tolerations = local.nvidia_operator_daemonset_tolerations
+      }
+      "node-feature-discovery" = {
+        worker = {
+          tolerations = local.nvidia_operator_nfd_worker_tolerations
+        }
+      }
       operator = {
         runtimeClass = "nvidia"
       }


### PR DESCRIPTION
## Summary
- add eyelevel_node NO_SCHEDULE taints to the Terraform-managed GPU node groups
- change the default ranker GPU node instance type from g4dn.2xlarge to g6e.xlarge
- disable the NVIDIA operator-owned DCGM exporter in the operator values
- add NVIDIA operator tolerations for GroundX GPU node taints in both src/groundx and the packaged helm mirror
- update the operator README default EC2 resource list

## Why
The Helm chart already schedules GPU workloads with eyelevel_node selectors and matching tolerations. Terraform only applied labels, so general pods could land on expensive GPU nodes and block scale-down.

The NVIDIA operator also has to tolerate those GPU node taints. Otherwise driver, device-plugin, validator, and NFD worker pods can miss the tainted ranker node. The DCGM exporter is disabled because CloudWatch already provides the DCGM exporter path and the NVIDIA-owned exporter was the component keeping ClusterPolicy unhealthy.

## Validation
- rendered nvidia/gpu-operator with src/groundx/values/nvidia/values.yaml
- rendered nvidia/gpu-operator with src/groundx/values/nvidia/values.aks.yaml
- rendered nvidia/gpu-operator with src/groundx/values/chainguard/values.nvidia.yaml
- rendered the matching helm/values mirror files
- confirmed rendered ClusterPolicy has dcgmExporter.enabled: false
- confirmed rendered operator/NFD resources include nvidia.com/gpu and eyelevel_node tolerations
- confirmed src/groundx NVIDIA values match the helm/ mirror files
- helm unittest src/groundx: 147 passed, 813 snapshots passed
- static regression check confirmed all GPU node groups have eyelevel_node taints and ranker defaults to g6e.xlarge
- git diff --check
- terraform -chdir=terraform/aws/eks init -backend=false -input=false
- terraform -chdir=terraform/aws/eks validate
- GitHub helm-unittest passed on the latest commit

## Related
- Points at EyeLevel-ai/ai-server#39, which is the working ai-server branch for ranker health/readiness until ready to merge to master.

Note: I did not run broad terraform fmt -recursive because this repo has broken local env.auto.tfvars symlinks and pre-existing Terraform format drift; running it produced unrelated whitespace churn.