### PR TITLE
Use windowed busy metric for ranker inference HPA

### DIFF
--- a/helm/templates/_helpers/app/ranker-inference.tpl
+++ b/helm/templates/_helpers/app/ranker-inference.tpl
@@ -67,7 +67,7 @@ true
 
 {{/* fraction of threshold */}}
 {{- define "groundx.ranker.inference.target.default" -}}
-1
+0.9
 {{- end }}
 
 {{/* queue message backlog */}}
@@ -113,7 +113,7 @@ true
 {{- $cfg := dict
   "downCooldown" (mul $cld 2)
   "enabled"      $enabled
-  "metric"       (printf "%s:task" $name)
+  "metric"       (printf "%s:inference" $name)
   "name"         $name
   "replicas"     $rep
   "throughput"   (printf "%s:throughput" $name)
@@ -126,6 +126,17 @@ true
 {{- $b := .Values.ranker | default dict -}}
 {{- $in := dig "inference" dict $b -}}
 {{ (dig "queue" "inference_queue" $in) }}
+{{- end }}
+
+{{- define "groundx.ranker.inference.busyWindowSeconds" -}}
+{{- $b := .Values.ranker | default dict -}}
+{{- $in := dig "inference" dict $b -}}
+{{- $rep := (include "groundx.ranker.inference.replicas" . | fromYaml) -}}
+{{- if dig "hpa" false $rep -}}
+{{ dig "busyWindowSeconds" 60 $in }}
+{{- else -}}
+0
+{{- end -}}
 {{- end }}
 
 {{- define "groundx.ranker.inference.replicas" -}}

--- a/helm/templates/resources/config-yaml.yaml
+++ b/helm/templates/resources/config-yaml.yaml
@@ -24,7 +24,7 @@
 {{- $wrac := include "groundx.workspace.api.threshold" . | trim -}}
 
 {{- $lic := include "groundx.layout.inference.threshold" . | trim -}}
-{{- $ric := include "groundx.ranker.inference.threshold" . | trim -}}
+{{- $ribw := include "groundx.ranker.inference.busyWindowSeconds" . | trim -}}
 {{- $sac := include "groundx.summary.api.threshold" . | trim -}}
 {{- $sic := include "groundx.summary.inference.threshold" . | trim -}}
 {{- $scc := include "groundx.summaryClient.threshold" . | trim -}}
@@ -273,11 +273,15 @@ data:
         tokensPerMinute: {{ include "groundx.throughput.tpm.document" . }}
       extractRequest:
         tokensPerMinute: {{ include "groundx.throughput.tpm.extractRequest" . }}
-      {{- if or (ne $lic "0") (ne $sac "0") (ne $sic "0") (and (eq $sce "true") (ne $scc "0")) }}
+      {{- if or (ne $lic "0") (ne $ribw "0") (ne $sac "0") (ne $sic "0") (and (eq $sce "true") (ne $scc "0")) }}
       inference:
         {{- if ne $lic "0" }}
         - name: {{ include "groundx.layout.serviceName" . }}-inference
           tokensPerMinute: {{ $lic }}
+        {{- end }}
+        {{- if ne $ribw "0" }}
+        - name: {{ include "groundx.ranker.inference.serviceName" . }}
+          busyWindowSeconds: {{ $ribw }}
         {{- end }}
         {{- if ne $sac "0" }}
         - name: {{ include "groundx.summary.api.serviceName" . }}
@@ -327,16 +331,9 @@ data:
         addr: {{ printf "%s:%v" (include "groundx.metrics.cache.addr" .) (include "groundx.metrics.cache.port" .) }}
         notCluster: {{ include "groundx.metrics.cache.notCluster" . }}
         ssl: {{ include "groundx.metrics.cache.ssl" . }}
-      {{- if eq (include "groundx.ranker.cache.existing" .) "true" }}
-      sessions:
-        {{ include "groundx.ranker.inference.serviceName" . }}:
-          addr: {{ printf "%s:%v" (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) }}
-          notCluster: {{ include "groundx.ranker.cache.notCluster" . }}
-          ssl: {{ include "groundx.ranker.cache.ssl" . }}
-      {{- end }}
       summaryRequest:
         tokensPerMinute: {{ include "groundx.throughput.tpm.summaryRequest" . }}
-      {{- if or (ne $eac "0") (ne $edc "0") (ne $esc "0") (ne $lcc "0") (ne $lmc "0") (ne $loc "0") (ne $lpc "0") (ne $lsc "0") (ne $ric "0") (ne $wrcuc "0") (ne $wrcc "0") (ne $wrpc "0") (ne $wrpubc "0") (ne $wrwc "0") }}
+      {{- if or (ne $eac "0") (ne $edc "0") (ne $esc "0") (ne $lcc "0") (ne $lmc "0") (ne $loc "0") (ne $lpc "0") (ne $lsc "0") (ne $wrcuc "0") (ne $wrcc "0") (ne $wrpc "0") (ne $wrpubc "0") (ne $wrwc "0") }}
       task:
         {{- if ne $eac "0" }}
         - name: {{ include "groundx.extract.agent.serviceName" . }}
@@ -377,14 +374,6 @@ data:
         - name: {{ include "groundx.layout.save.serviceName" . }}
           target: {{ include "groundx.layout.save.queue" . }}
           threshold: {{ $lsc }}
-        {{- end }}
-        {{- if ne $ric "0" }}
-        - name: {{ include "groundx.ranker.inference.serviceName" . }}
-          {{- if eq (include "groundx.ranker.cache.existing" .) "true" }}
-          session: {{ include "groundx.ranker.inference.serviceName" . }}
-          {{- end }}
-          target: {{ include "groundx.ranker.inference.queue" . }}
-          threshold: {{ $ric }}
         {{- end }}
         {{- if ne $wrcuc "0" }}
         - name: {{ include "groundx.workspace.cleanup.metricName" . }}

--- a/helm/templates/resources/ranker-config-py.yaml
+++ b/helm/templates/resources/ranker-config-py.yaml
@@ -17,6 +17,9 @@ data:
         deviceType={{ include "groundx.ranker.inference.deviceType" . | quote }},
         brokerType={{ include "groundx.ranker.cache.type" . | quote }},
         metricsBroker={{ printf "%s://%s:%v/0" (include "groundx.metrics.cache.scheme" .) (include "groundx.metrics.cache.addr" .) (include "groundx.metrics.cache.port" .) | quote }},
+        {{- if ne (include "groundx.ranker.inference.busyWindowSeconds" . | trim) "0" }}
+        metricsBusyWindowSeconds={{ include "groundx.ranker.inference.busyWindowSeconds" . }},
+        {{- end }}
         searchBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},
         searchLog={{ include "groundx.ranker.serviceName" . | quote }},
         searchResultBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1212,7 +1212,8 @@
               "properties": {
                 "desired": { "type": "integer" },
                 "max": { "type": "integer" },
-                "min": { "type": "integer" }
+                "min": { "type": "integer" },
+                "target": { "type": "number" }
               },
               "required": ["desired"],
               "additionalProperties": false

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1241,6 +1241,7 @@
           "properties": {
             "affinity": { "type": "object" },
             "annotations": { "type": "object" },
+            "busyWindowSeconds": { "type": "integer", "minimum": 1 },
             "containerPort": { "type": "integer" },
             "containerSecurityContext": { "type": "object" },
             "deviceType": { "type": "string" },

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/design.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/design.md
@@ -1,9 +1,9 @@
-# Ranker Inference Queue Back-Pressure HPA Design
+# Ranker Inference Windowed Busy HPA Design
 
 ## Goal
 
-Reuse the existing Celery task backlog autoscaling implementation for ranker
-inference with the smallest chart change.
+Scale ranker inference from a stable per-pod busy-time signal instead of a
+point-in-time worker sample or queue backlog.
 
 ## HPA Contract
 
@@ -11,55 +11,53 @@ The rendered ranker inference HPA uses two external metrics:
 
 ```text
 ranker-inference:throughput
-ranker-inference:task
+ranker-inference:inference
 ```
 
 `ranker-inference:throughput` stays as the existing pipeline throughput axis.
-`ranker-inference:task` becomes the pod-specific back-pressure axis.
+`ranker-inference:inference` becomes the pod-specific busy-time axis.
 
 ## Metrics Config
 
-The chart renders ranker inference in `metrics.task`:
+The chart renders ranker inference in `metrics.inference`:
 
 ```yaml
-task:
+inference:
   - name: ranker-inference
-    target: inference_queue
-    threshold: 10
+    busyWindowSeconds: 60
 ```
 
-The ranker inference entry is removed from `metrics.inference`.
+The ranker inference entry is removed from `metrics.task`.
 
-cashbot-go already implements `task` metrics by reading
-`{celery}<target queue>` and dividing the backlog by `threshold`. Without a
-ranker cache override, the ranker inference task metric uses the same process
-Redis path as the existing task backlog metrics.
+cashbot-go computes this metric from the existing metrics Redis session:
 
-When `ranker.cache.addr` is set, the chart also renders:
+- ai-server marks a worker busy when ranker inference starts handling a task.
+- ai-server marks the worker available in `finally` and writes elapsed
+  milliseconds into second-sized Redis buckets.
+- cashbot-go sums completed busy buckets inside the configured window.
+- cashbot-go also counts currently active workers from their busy start keys,
+  capped to the same window.
+- The external metric value is busy milliseconds divided by
+  `online workers * busyWindowSeconds`.
 
-```yaml
-sessions:
-  ranker-inference:
-    addr: <ranker cache addr>:<ranker cache port>
-    notCluster: <derived from ranker.cache.isCluster>
-    ssl: <ranker cache ssl>
-task:
-  - name: ranker-inference
-    session: ranker-inference
-    target: inference_queue
-    threshold: 10
-```
+For windowed inference metrics, cashbot-go does not use the old instantaneous
+availability sample.
 
-When ranker uses the global cache, `sessions.ranker-inference` and the task
-`session` field are omitted.
+## Redis Contract
 
-## Threshold
+Ranker busy samples are written to the same Redis configured by `metricsBroker`.
+That is the existing metrics cache in the chart.
 
-The default ranker inference task threshold is `10`, matching the existing task
-backlog default documented in the GroundX Studio Harness autoscaling reference.
+If `ranker.cache.addr` is set, ranker search/Celery brokers use that ranker
+cache, but the busy HPA metric still uses `metrics.session`. The chart does not
+render `metrics.sessions.ranker-inference` for the busy metric.
 
-A threshold of `1` is intentionally avoided because one queued ranker task would
-report full utilization and can make GPU HPA behavior too sensitive.
+## Sensitivity
+
+The default window is `60` seconds. The default HPA target is `0.9`, so a
+single one-second request on one worker reports about `0.0167`, not `1.0`.
+Sustained saturation across the window is required before the pod-specific
+metric reaches the scale target.
 
 ## Source And Mirror
 
@@ -72,8 +70,9 @@ Because ranker inference pods can require GPU node launch plus model readiness,
 rendered correctness is not enough. After approval, validate under a controlled
 ramp while watching:
 
-- `ranker-inference:task`
-- `LLEN {celery}inference_queue`
+- `ranker-inference:inference`
+- Redis `ranker-inference:*:busy_start_ms`
+- Redis `ranker-inference:busy:*:ms`
 - HPA events
 - Pending pods
 - GPU node readiness
@@ -81,12 +80,11 @@ ramp while watching:
 - ranker API latency
 - Lambda duration and errors
 
-If `ranker.cache.addr` is overridden, confirm the metrics server reads the Redis
-instance that owns `{celery}inference_queue`.
+If `ranker.cache.addr` is overridden, confirm ranker search/Celery uses the
+ranker cache while busy samples still land in the metrics cache.
 
 ## Non-Goals
 
 - No ranker API HPA or capacity metric change.
-- No new cashbot-go task metric algorithm.
-- No ai-server image, worker-health, or ranker-specific metric change.
+- No task backlog metric change for other Celery workers.
 - No node, GPU, Cluster Autoscaler, secret, search, ranking, or data change.

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/proposal.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/proposal.md
@@ -1,34 +1,39 @@
-# Use Ranker Inference Queue Back-Pressure HPA
+# Use Windowed Ranker Inference Busy HPA
 
 ## Why
 
-Ranker inference is a Celery worker pool, but the chart rendered its
-pod-specific HPA signal as `ranker-inference:inference`. That older signal uses
-point-in-time model worker state and can miss pressure between HPA samples.
+Ranker inference is a Celery worker pool running long GPU tasks. Queue backlog
+was a poor HPA signal because one queued request could make the metric look
+fully saturated even while a single replica was still healthy. The older
+`ranker-inference:inference` signal was also too point-in-time because it
+sampled whether a worker happened to be busy when the metrics server checked.
 
-Other Celery workers already scale from queue backlog through the existing
-cashbot-go `task` metric. The smallest chart fix is to wire ranker inference to
-that same queue back-pressure path.
+The fix is to make `ranker-inference:inference` mean average busy time over a
+short window. ai-server records busy starts/finishes into the existing metrics
+Redis, cashbot-go reads those samples through the existing metrics session, and
+the chart wires ranker inference to that metric.
 
 ## What Changes
 
 - Render the ranker inference pod-specific HPA metric as
-  `ranker-inference:task`.
+  `ranker-inference:inference`.
 - Keep `ranker-inference:throughput` as the pipeline throughput axis.
-- Move ranker inference metrics config from `metrics.inference` to
-  `metrics.task`.
-- Render the ranker task session key from the ranker inference service name
-  only when `ranker.cache.addr` selects a separate ranker cache.
-- Set the ranker task target to `inference_queue`.
-- Default the ranker task threshold to the existing task backlog default, `10`.
-- Keep the shared HPA cooldown behavior unchanged.
+- Render ranker inference under `metrics.inference` with
+  `busyWindowSeconds`, defaulting to `60`.
+- Pass the same `metricsBusyWindowSeconds` value to ranker ai-server config.
+- Keep ranker busy samples on the existing `metrics.session` Redis path. If
+  `ranker.cache.addr` is overridden, search/Celery traffic uses that ranker
+  cache, but the HPA busy metric still uses the metrics cache.
+- Remove ranker inference from `metrics.task`; no ranker-specific
+  `metrics.sessions` block is rendered for this metric.
+- Default the HPA target to `0.9`.
 - Mirror source chart changes into `helm/`.
+- Add the cashbot-go reader and ai-server writer changes required by this
+  chart contract.
 
 ## Out Of Scope
 
 - No ranker API HPA change.
-- No new cashbot-go metric type.
-- No ai-server image or health contract change.
 - No search, ranking, OpenSearch, node group, Cluster Autoscaler, secret, or
   stateful resource change.
 - No deployment without separate approval.
@@ -36,21 +41,23 @@ that same queue back-pressure path.
 ## Rollout
 
 1. Deploy the chart change after approval.
-2. Confirm the deployed ranker inference HPA uses `ranker-inference:task` and
+2. Confirm the deployed ranker inference HPA uses `ranker-inference:inference`
+   and
    `ranker-inference:throughput`.
-3. Confirm rendered `config.yaml` lists ranker inference under `metrics.task`
-   with `target: inference_queue` and `threshold: 10`; if `ranker.cache.addr`
-   is set, confirm it also includes `session: ranker-inference` and
-   `metrics.sessions.ranker-inference`.
-4. At idle, confirm `ranker-inference:task` remains near zero.
-5. During a controlled ramp, compare `LLEN {celery}inference_queue` with the
-   Kubernetes external metric.
+3. Confirm rendered `config.yaml` lists ranker inference under
+   `metrics.inference` with `busyWindowSeconds: 60`.
+4. Confirm rendered ranker config includes `metricsBusyWindowSeconds=60` and
+   points `metricsBroker` at the metrics cache.
+5. At idle, confirm `ranker-inference:inference` remains near zero.
+6. During a controlled ramp, compare active/in-flight ranker requests with the
+   Kubernetes external metric over the configured window.
 6. Watch HPA events, Pending pods, GPU node readiness, model readiness,
    ranker-inference CPU/GPU, ranker API latency, and Lambda duration/errors.
-7. Tune `ranker.inference.replicas.threshold` only from live ramp data.
+7. Tune `ranker.inference.busyWindowSeconds` or
+   `ranker.inference.replicas.target` only from live ramp data.
 
 ## Rollback
 
-Roll back the chart to the previous ranker inference HPA metric if
-`ranker-inference:task` does not match live broker state. No data rollback is
+Disable `ranker.inference.busyWindowSeconds` and roll back the chart/app images
+if the windowed metric does not match live ranker activity. No data rollback is
 required.

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/specs/ranker-inference-autoscaling/spec.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/specs/ranker-inference-autoscaling/spec.md
@@ -1,8 +1,8 @@
 ## ADDED Requirements
 
-### Requirement: Ranker Inference HPA Uses Celery Queue Back-Pressure
+### Requirement: Ranker Inference HPA Uses Windowed Busy Time
 
-Ranker inference HPA SHALL use the existing Celery task backlog metric for
+Ranker inference HPA SHALL use a windowed busy-time inference metric for
 pod-specific autoscaling pressure.
 
 #### Scenario: Ranker inference HPA is rendered
@@ -10,44 +10,66 @@ pod-specific autoscaling pressure.
 - **GIVEN** ranker inference HPA is enabled
 - **WHEN** the chart renders the ranker inference HPA
 - **THEN** it includes `ranker-inference:throughput`
-- **AND** it includes `ranker-inference:task`
-- **AND** it does not use `ranker-inference:inference` as the pod-specific
-  metric.
+- **AND** it includes `ranker-inference:inference` as the pod-specific metric
+- **AND** the default HPA target is below `1`.
 
-#### Scenario: Ranker inference task config is rendered
+#### Scenario: Ranker inference busy config is rendered
 
 - **GIVEN** ranker inference is enabled
+- **AND** ranker inference HPA is enabled
 - **WHEN** the chart renders `config.yaml`
-- **THEN** `metrics.task` includes `ranker-inference`
-- **AND** its target is `inference_queue`
-- **AND** its threshold defaults to `10`
-- **AND** it does not render a ranker-specific task session without an explicit
-  ranker cache override
-- **AND** `metrics.inference` does not include `ranker-inference`.
+- **THEN** `metrics.inference` includes `ranker-inference`
+- **AND** its `busyWindowSeconds` defaults to `60`
+- **AND** `metrics.task` does not include `ranker-inference`
+- **AND** it does not render `metrics.sessions.ranker-inference`.
 
-#### Scenario: Ranker cache override renders service-named metrics session
+#### Scenario: Ranker inference busy config is omitted when HPA is disabled
+
+- **GIVEN** ranker inference is enabled
+- **AND** ranker inference HPA is disabled
+- **WHEN** the chart renders `config.yaml`, ranker `config.py`, and HPA resources
+- **THEN** `metrics.inference` does not include ranker busy config
+- **AND** ranker `config.py` does not enable `metricsBusyWindowSeconds`
+- **AND** no ranker inference HPA is rendered.
+
+#### Scenario: Ranker config receives busy window
+
+- **GIVEN** ranker inference is enabled
+- **AND** ranker inference HPA is enabled
+- **WHEN** the chart renders ranker `config.py`
+- **THEN** it includes `metricsBusyWindowSeconds=60`
+- **AND** `metricsBroker` points at the metrics cache.
+
+#### Scenario: Offline monitor events do not create busy intervals
+
+- **GIVEN** ranker inference busy metrics are enabled
+- **WHEN** a Celery monitor reports a worker offline
+- **THEN** the status writer does not create a new busy-start key
+- **AND** no busy bucket is written from that offline event.
+
+#### Scenario: Ranker cache override does not move busy metrics
 
 - **GIVEN** ranker inference is enabled
 - **AND** `ranker.cache.addr` is set
-- **WHEN** the chart renders `config.yaml`
-- **THEN** `metrics.sessions` includes `ranker-inference`
-- **AND** the task metric session is `ranker-inference`.
+- **WHEN** the chart renders ranker config and `config.yaml`
+- **THEN** ranker search brokers use the ranker cache
+- **AND** `metricsBroker` still uses the metrics cache
+- **AND** `metrics.sessions.ranker-inference` is not rendered.
 
 #### Scenario: Published chart mirror stays aligned
 
 - **WHEN** the ranker inference HPA and config templates are compared
-- **THEN** `src/groundx` and `helm` contain the same queue back-pressure
+- **THEN** `src/groundx` and `helm` contain the same windowed busy metric
   contract.
 
 ### Requirement: Other Ranker Surfaces Stay Unchanged
 
-This change SHALL NOT modify ranker API HPA behavior, ranker application code,
-node provisioning, secrets, search behavior, ranking behavior, or stateful
-resources.
+This change SHALL NOT modify ranker API HPA behavior, node provisioning,
+secrets, search behavior, ranking behavior, or stateful resources.
 
 #### Scenario: The implementation diff is reviewed
 
 - **WHEN** the implementation diff is reviewed
 - **THEN** there is no ranker API capacity metric change
-- **AND** there is no ai-server or cashbot-go production algorithm change
+- **AND** other Celery task backlog metrics are unchanged
 - **AND** deployment still requires explicit approval.

--- a/openspec/changes/fix-ranker-inference-hpa-readiness/tasks.md
+++ b/openspec/changes/fix-ranker-inference-hpa-readiness/tasks.md
@@ -1,56 +1,72 @@
-# Ranker Inference Queue Back-Pressure HPA Tasks
+# Ranker Inference Windowed Busy HPA Tasks
 
 ## 1. Confirm Existing Pattern
 
 - [x] Re-read repo instructions and the GroundX Studio Harness autoscaling
       guidance.
-- [x] Confirm task backlog metrics default to threshold `10`.
 - [x] Confirm ranker inference uses Celery queue `inference_queue`.
-- [x] Confirm cashbot-go already implements the `task` metric path.
+- [x] Confirm queue backlog is too sensitive for this workload.
+- [x] Confirm point-in-time inference availability sampling can miss pressure
+      between metric polls.
 - [x] Confirm implementation must stop before deployment.
 
-## 2. Implement Chart Change
+## 2. Implement Cross-Repo Metric
 
-- [x] Switch ranker inference HPA from `ranker-inference:inference` to
-      `ranker-inference:task`.
+- [x] Add ai-server busy start/finish recording on ranker inference worker
+      unavailable/available transitions.
+- [x] Write completed busy milliseconds into short Redis buckets.
+- [x] Keep active start keys for in-flight work so unfinished requests count.
+- [x] Add cashbot-go reader support for `busyWindowSeconds` inference metrics.
+- [x] Keep non-windowed inference services on the existing instantaneous
+      availability behavior.
+
+## 3. Implement Chart Change
+
+- [x] Keep ranker inference HPA on `ranker-inference:inference`.
 - [x] Keep `ranker-inference:throughput`.
-- [x] Move ranker inference config from `metrics.inference` to `metrics.task`.
-- [x] Set target queue to `inference_queue`.
-- [x] Set default threshold to `10`.
-- [x] Render the ranker inference service name as the task metric `session`
-      only when `ranker.cache.addr` selects a separate ranker cache.
-- [x] Render `metrics.sessions.<ranker inference service name>` from
-      `ranker.cache` when a separate ranker cache is configured.
-- [x] Add `ranker.cache.isCluster` support so the metrics Redis client can use
-      the same cluster/simple connection mode as existing cache overrides.
-- [x] Keep the shared HPA cooldown behavior unchanged.
+- [x] Render ranker inference under `metrics.inference` with
+      `busyWindowSeconds: 60`.
+- [x] Omit ranker busy metrics and writer config when ranker inference HPA is
+      disabled.
+- [x] Remove ranker inference from `metrics.task`.
+- [x] Do not render a ranker-specific metrics session for the busy metric.
+- [x] Pass `metricsBusyWindowSeconds` to ranker ai-server config.
+- [x] Default the HPA target to `0.9`.
 - [x] Mirror the changed source templates into `helm/`.
-- [x] Leave ranker API HPA, ai-server, node settings, secrets, and stateful
+- [x] Leave ranker API HPA, node settings, secrets, and stateful
       resources unchanged.
 
-## 3. Validate
+## 4. Validate
 
 - [x] Add Helm test coverage for the ranker inference HPA metric names.
-- [x] Add Helm test coverage for the generated `metrics.task` config.
-- [x] Add Helm test coverage for ranker cache override metrics config.
+- [x] Add Helm test coverage for the generated `metrics.inference` busy config.
+- [x] Add Helm test coverage that ranker busy config is omitted when HPA is
+      disabled.
+- [x] Add Helm test coverage that ranker cache override does not render a
+      separate metrics task session.
+- [x] Add ai-server unit coverage for busy start/finish bucket writes.
+- [x] Add ai-server unit coverage that monitor offline events do not create busy
+      intervals.
+- [x] Add cashbot-go unit coverage for bucket/start reading and metric compute.
 - [x] Regenerate Helm snapshots with `helm unittest -u src/groundx`.
 - [x] Run focused ranker Helm tests.
 - [x] Run the full Helm unit test suite.
 - [x] Render the chart and inspect ranker inference HPA/config output.
 - [x] Run `helm lint`.
-- [x] Run OpenSpec validation.
 - [x] Run `git diff --check`.
+- [x] Run `npx --yes @fission-ai/openspec@1.3.1 validate
+      fix-ranker-inference-hpa-readiness --strict`.
 
-## 4. Post-Approval Deployment Test Plan
+## 5. Post-Approval Deployment Test Plan
 
 - [ ] Deploy the chart change after explicit approval.
 - [ ] Confirm deployed HPA and metrics server versions.
-- [ ] Confirm `ranker-inference:task` is near zero at idle.
-- [ ] Confirm `{celery}inference_queue` backlog explains the external metric.
+- [ ] Confirm `ranker-inference:inference` is near zero at idle.
+- [ ] Confirm busy start/bucket Redis keys explain the external metric.
 - [ ] If `ranker.cache.addr` is overridden, confirm the metrics server reads the
-      same Redis instance that owns `{celery}inference_queue`.
+      metrics cache while ranker search/Celery uses the ranker cache.
 - [ ] Run a controlled ramp that exercises ranker inference.
-- [ ] Watch `ranker-inference:task`, `ranker-inference:throughput`,
-      `inference_queue` depth, HPA events, pending pods, GPU node readiness,
-      model readiness, ranker API latency, and Lambda duration/errors.
-- [ ] Tune threshold only from observed queue depth and scale-up timing.
+- [ ] Watch `ranker-inference:inference`, `ranker-inference:throughput`,
+      busy Redis keys, HPA events, pending pods, GPU node readiness, model
+      readiness, ranker API latency, and Lambda duration/errors.
+- [ ] Tune `busyWindowSeconds` or HPA target only from observed scale timing.

--- a/src/groundx/templates/_helpers/app/ranker-inference.tpl
+++ b/src/groundx/templates/_helpers/app/ranker-inference.tpl
@@ -67,7 +67,7 @@ true
 
 {{/* fraction of threshold */}}
 {{- define "groundx.ranker.inference.target.default" -}}
-1
+0.9
 {{- end }}
 
 {{/* queue message backlog */}}
@@ -113,7 +113,7 @@ true
 {{- $cfg := dict
   "downCooldown" (mul $cld 2)
   "enabled"      $enabled
-  "metric"       (printf "%s:task" $name)
+  "metric"       (printf "%s:inference" $name)
   "name"         $name
   "replicas"     $rep
   "throughput"   (printf "%s:throughput" $name)
@@ -126,6 +126,17 @@ true
 {{- $b := .Values.ranker | default dict -}}
 {{- $in := dig "inference" dict $b -}}
 {{ (dig "queue" "inference_queue" $in) }}
+{{- end }}
+
+{{- define "groundx.ranker.inference.busyWindowSeconds" -}}
+{{- $b := .Values.ranker | default dict -}}
+{{- $in := dig "inference" dict $b -}}
+{{- $rep := (include "groundx.ranker.inference.replicas" . | fromYaml) -}}
+{{- if dig "hpa" false $rep -}}
+{{ dig "busyWindowSeconds" 60 $in }}
+{{- else -}}
+0
+{{- end -}}
 {{- end }}
 
 {{- define "groundx.ranker.inference.replicas" -}}

--- a/src/groundx/templates/resources/config-yaml.yaml
+++ b/src/groundx/templates/resources/config-yaml.yaml
@@ -24,7 +24,7 @@
 {{- $wrac := include "groundx.workspace.api.threshold" . | trim -}}
 
 {{- $lic := include "groundx.layout.inference.threshold" . | trim -}}
-{{- $ric := include "groundx.ranker.inference.threshold" . | trim -}}
+{{- $ribw := include "groundx.ranker.inference.busyWindowSeconds" . | trim -}}
 {{- $sac := include "groundx.summary.api.threshold" . | trim -}}
 {{- $sic := include "groundx.summary.inference.threshold" . | trim -}}
 {{- $scc := include "groundx.summaryClient.threshold" . | trim -}}
@@ -273,11 +273,15 @@ data:
         tokensPerMinute: {{ include "groundx.throughput.tpm.document" . }}
       extractRequest:
         tokensPerMinute: {{ include "groundx.throughput.tpm.extractRequest" . }}
-      {{- if or (ne $lic "0") (ne $sac "0") (ne $sic "0") (and (eq $sce "true") (ne $scc "0")) }}
+      {{- if or (ne $lic "0") (ne $ribw "0") (ne $sac "0") (ne $sic "0") (and (eq $sce "true") (ne $scc "0")) }}
       inference:
         {{- if ne $lic "0" }}
         - name: {{ include "groundx.layout.serviceName" . }}-inference
           tokensPerMinute: {{ $lic }}
+        {{- end }}
+        {{- if ne $ribw "0" }}
+        - name: {{ include "groundx.ranker.inference.serviceName" . }}
+          busyWindowSeconds: {{ $ribw }}
         {{- end }}
         {{- if ne $sac "0" }}
         - name: {{ include "groundx.summary.api.serviceName" . }}
@@ -327,16 +331,9 @@ data:
         addr: {{ printf "%s:%v" (include "groundx.metrics.cache.addr" .) (include "groundx.metrics.cache.port" .) }}
         notCluster: {{ include "groundx.metrics.cache.notCluster" . }}
         ssl: {{ include "groundx.metrics.cache.ssl" . }}
-      {{- if eq (include "groundx.ranker.cache.existing" .) "true" }}
-      sessions:
-        {{ include "groundx.ranker.inference.serviceName" . }}:
-          addr: {{ printf "%s:%v" (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) }}
-          notCluster: {{ include "groundx.ranker.cache.notCluster" . }}
-          ssl: {{ include "groundx.ranker.cache.ssl" . }}
-      {{- end }}
       summaryRequest:
         tokensPerMinute: {{ include "groundx.throughput.tpm.summaryRequest" . }}
-      {{- if or (ne $eac "0") (ne $edc "0") (ne $esc "0") (ne $lcc "0") (ne $lmc "0") (ne $loc "0") (ne $lpc "0") (ne $lsc "0") (ne $ric "0") (ne $wrcuc "0") (ne $wrcc "0") (ne $wrpc "0") (ne $wrpubc "0") (ne $wrwc "0") }}
+      {{- if or (ne $eac "0") (ne $edc "0") (ne $esc "0") (ne $lcc "0") (ne $lmc "0") (ne $loc "0") (ne $lpc "0") (ne $lsc "0") (ne $wrcuc "0") (ne $wrcc "0") (ne $wrpc "0") (ne $wrpubc "0") (ne $wrwc "0") }}
       task:
         {{- if ne $eac "0" }}
         - name: {{ include "groundx.extract.agent.serviceName" . }}
@@ -377,14 +374,6 @@ data:
         - name: {{ include "groundx.layout.save.serviceName" . }}
           target: {{ include "groundx.layout.save.queue" . }}
           threshold: {{ $lsc }}
-        {{- end }}
-        {{- if ne $ric "0" }}
-        - name: {{ include "groundx.ranker.inference.serviceName" . }}
-          {{- if eq (include "groundx.ranker.cache.existing" .) "true" }}
-          session: {{ include "groundx.ranker.inference.serviceName" . }}
-          {{- end }}
-          target: {{ include "groundx.ranker.inference.queue" . }}
-          threshold: {{ $ric }}
         {{- end }}
         {{- if ne $wrcuc "0" }}
         - name: {{ include "groundx.workspace.cleanup.metricName" . }}

--- a/src/groundx/templates/resources/ranker-config-py.yaml
+++ b/src/groundx/templates/resources/ranker-config-py.yaml
@@ -17,6 +17,9 @@ data:
         deviceType={{ include "groundx.ranker.inference.deviceType" . | quote }},
         brokerType={{ include "groundx.ranker.cache.type" . | quote }},
         metricsBroker={{ printf "%s://%s:%v/0" (include "groundx.metrics.cache.scheme" .) (include "groundx.metrics.cache.addr" .) (include "groundx.metrics.cache.port" .) | quote }},
+        {{- if ne (include "groundx.ranker.inference.busyWindowSeconds" . | trim) "0" }}
+        metricsBusyWindowSeconds={{ include "groundx.ranker.inference.busyWindowSeconds" . }},
+        {{- end }}
         searchBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},
         searchLog={{ include "groundx.ranker.serviceName" . | quote }},
         searchResultBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},

--- a/src/groundx/tests/__snapshot__/api_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/api_test.yaml.snap
@@ -157,7 +157,7 @@
       template:
         metadata:
           annotations:
-            config-hash: b0c8193aca6eccd6282f680fa67313a44dd0ac24a73ea84906276482bde9c15e
+            config-hash: f67d6c0b16d56b65f28b97d06e08e0aec8d20d7b324a10f6e071a4856bebb1f4
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -723,7 +723,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
+            config-hash: 7dcb7a1ab9ac4d7799ca43ec2a1f137237fa1977f3f2230561ba4a952a4ea6f5
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -1135,7 +1135,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d09038b15d81b45a3c91b675dba9421905acbd940eca1349b6af31098c98c043
+            config-hash: 6cb56bdce3ae5cbac499f49f35bcdff7c7738084f55cd3489385a100dd14874d
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -1548,7 +1548,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d09038b15d81b45a3c91b675dba9421905acbd940eca1349b6af31098c98c043
+            config-hash: 6cb56bdce3ae5cbac499f49f35bcdff7c7738084f55cd3489385a100dd14874d
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -1960,7 +1960,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8e63ebfea1c0f60ac40bef43a8944a14369538ba8bb0421a10a4a0be5a804b9e
+            config-hash: e39edcfb8cb84e1324f76f399b4526e6fa20efb448fb13f6e11703b07ce3853c
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -2392,7 +2392,7 @@
       template:
         metadata:
           annotations:
-            config-hash: b9925462022bebe3881e71f27efbc04bb7bfd6e0f9e2e70a62d76cfcc676d69d
+            config-hash: e1f52d4e87b2647506b765c07804a6f3926def037f5ae8e2bbddc96b8a68fef3
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -2964,7 +2964,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 1c478ed103e29a5ca3e1fea4246d3385551c8f60f4141a412bdd8afdfa5115ab
+            config-hash: 0ac0be5132769dab8e511fda8bdc0106793d183e0620921447bf068570d67725
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -3533,7 +3533,7 @@
       template:
         metadata:
           annotations:
-            config-hash: b9925462022bebe3881e71f27efbc04bb7bfd6e0f9e2e70a62d76cfcc676d69d
+            config-hash: e1f52d4e87b2647506b765c07804a6f3926def037f5ae8e2bbddc96b8a68fef3
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -3813,7 +3813,7 @@
       template:
         metadata:
           annotations:
-            config-hash: db12e6d22be007fc52ee601f6989646694bae2a985f615c39bcfef2d46258a3e
+            config-hash: 6ebf39dc9528dd41fccf3abee945a2ce811738f044edf6b20d571c5a10260076
             gunicorn-conf-hash: a549b26517e32f7a8ffda2515b3c71d7e219de4734ba5efb1178364200945858
             prometheus.io/port: "8081"
           labels:
@@ -4186,7 +4186,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
+            config-hash: 7dcb7a1ab9ac4d7799ca43ec2a1f137237fa1977f3f2230561ba4a952a4ea6f5
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -4592,7 +4592,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
+            config-hash: 7dcb7a1ab9ac4d7799ca43ec2a1f137237fa1977f3f2230561ba4a952a4ea6f5
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -5129,7 +5129,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8c8d3d4f45d68a2a23457d8db11374d236b3e1b2f01730bbb2426421e92af4e5
+            config-hash: 6fd688a9c8fd15ff4d418640335dcdec32aa8a95df59c58bbdc85b4c03495ec7
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api

--- a/src/groundx/tests/__snapshot__/golang_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/golang_test.yaml.snap
@@ -19,7 +19,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: groundx
         spec:
@@ -159,7 +159,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: layout-webhook
         spec:
@@ -278,7 +278,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: pre-process
         spec:
@@ -381,7 +381,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: process
         spec:
@@ -484,7 +484,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: queue
         spec:
@@ -587,7 +587,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: summary-client
         spec:
@@ -690,7 +690,7 @@
       template:
         metadata:
           annotations:
-            config-hash: de0286f53395d5503ba6f6cfa7687f17c094e89a1f33e1a8ebb073bdb2ffcb85
+            config-hash: d43717bfcd2a03d1efecb12c46d41733ce979df2876e3fe0b64b503cdcd52770
           labels:
             app: upload
         spec:
@@ -794,7 +794,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: groundx
         spec:
@@ -940,7 +940,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: layout-webhook
         spec:
@@ -1058,7 +1058,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: pre-process
         spec:
@@ -1160,7 +1160,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: process
         spec:
@@ -1262,7 +1262,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: queue
         spec:
@@ -1364,7 +1364,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: summary-client
         spec:
@@ -1466,7 +1466,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8175feda930cd89e25ab6186af7177b3beb8bbb6df45a8f83a853ff346e3f4ad
+            config-hash: 08d36acc4476d3efef1cdddb5fdcf7bbd8536facb1b8e6c870e9750924cf52d3
           labels:
             app: upload
         spec:
@@ -1569,7 +1569,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: groundx
         spec:
@@ -1715,7 +1715,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: layout-webhook
         spec:
@@ -1833,7 +1833,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: pre-process
         spec:
@@ -1935,7 +1935,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: process
         spec:
@@ -2037,7 +2037,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: queue
         spec:
@@ -2139,7 +2139,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: summary-client
         spec:
@@ -2241,7 +2241,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: upload
         spec:
@@ -2345,7 +2345,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: groundx
         spec:
@@ -2491,7 +2491,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: layout-webhook
         spec:
@@ -2609,7 +2609,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: pre-process
         spec:
@@ -2711,7 +2711,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: process
         spec:
@@ -2813,7 +2813,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: queue
         spec:
@@ -2915,7 +2915,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: summary-client
         spec:
@@ -3017,7 +3017,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 03715b12afac7cf5158ac640142e5dbc63a92e32c4ab93717ce871e06b786db9
+            config-hash: 75f7615cfcb90b732f5a7b4974fc58fa9d1a99b1732f28ec0ef6204a29034833
           labels:
             app: upload
         spec:
@@ -3120,7 +3120,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: groundx
         spec:
@@ -3266,7 +3266,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: layout-webhook
         spec:
@@ -3384,7 +3384,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: pre-process
         spec:
@@ -3486,7 +3486,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: process
         spec:
@@ -3588,7 +3588,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: queue
         spec:
@@ -3690,7 +3690,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: summary-client
         spec:
@@ -3792,7 +3792,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 72cf966f95daee9c556c04b4e0dd577e403c29ae17d019cd0ad40c41c29532e4
+            config-hash: d3a3202b1c3bf8ce68467e3d812baf62081aa1f0f318f6fe2966130017397f51
           labels:
             app: upload
         spec:
@@ -3895,7 +3895,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: groundx
         spec:
@@ -4031,7 +4031,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: layout-webhook
         spec:
@@ -4153,7 +4153,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: pre-process
         spec:
@@ -4259,7 +4259,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: process
         spec:
@@ -4365,7 +4365,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: queue
         spec:
@@ -4471,7 +4471,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: summary-client
         spec:
@@ -4577,7 +4577,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 2745082bfebc829282fefd17ad75a87ccb77e1e429345954a1aff125584cb3e6
+            config-hash: 006e4208e9971c826beb91f2d8a164c8b8325e23eb52309efde8176e5b58c64b
           labels:
             app: upload
         spec:
@@ -4684,7 +4684,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: groundx
         spec:
@@ -4816,7 +4816,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: layout-webhook
         spec:
@@ -4934,7 +4934,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: pre-process
         spec:
@@ -5036,7 +5036,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: process
         spec:
@@ -5138,7 +5138,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: queue
         spec:
@@ -5240,7 +5240,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: summary-client
         spec:
@@ -5342,7 +5342,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cb13937fc96a1b4d3db10a8adcd67728079c0874be59b61ba549a164a07e3885
+            config-hash: 8fa6793ae449ff17d021f052bc92628eb2c88b0ca9685b4a852c286b3686ad3b
           labels:
             app: upload
         spec:
@@ -5445,7 +5445,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: groundx
         spec:
@@ -5581,7 +5581,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: layout-webhook
         spec:
@@ -5703,7 +5703,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: pre-process
         spec:
@@ -5809,7 +5809,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: process
         spec:
@@ -5915,7 +5915,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: queue
         spec:
@@ -6021,7 +6021,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: summary-client
         spec:
@@ -6127,7 +6127,7 @@
       template:
         metadata:
           annotations:
-            config-hash: aa251024d86429524ebdcc7c3d81923f68f5c0d3c85f0e48aeecbbe31e655917
+            config-hash: f7d50be90bdfbbdfc2f9fa331865b9b66082c9a0deb40ef96e5da0103f88e9a0
           labels:
             app: upload
         spec:
@@ -6234,7 +6234,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
             prometheus.io/port: "8081"
           labels:
             app: myapp
@@ -6364,7 +6364,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
           labels:
             app: layout-webhook
         spec:
@@ -6481,7 +6481,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
           labels:
             app: pre-process
         spec:
@@ -6586,7 +6586,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
           labels:
             app: process
         spec:
@@ -6689,7 +6689,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
           labels:
             app: queue
         spec:
@@ -6771,7 +6771,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
           labels:
             app: summary-client
         spec:
@@ -6858,7 +6858,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 776add65aaa8b025ab22a1bbd348db012de8f8be3dff263257d2913307869294
+            config-hash: 44b82bba0d6d36e04774d66e72a88ee903039041b9da14af66faf74fecafb458
           labels:
             app: upload
         spec:
@@ -6943,7 +6943,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: groundx
         spec:
@@ -7089,7 +7089,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: layout-webhook
         spec:
@@ -7207,7 +7207,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: pre-process
         spec:
@@ -7309,7 +7309,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: process
         spec:
@@ -7411,7 +7411,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: queue
         spec:
@@ -7513,7 +7513,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: summary-client
         spec:
@@ -7615,7 +7615,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: upload
         spec:
@@ -7718,7 +7718,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: groundx
         spec:
@@ -7858,7 +7858,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: layout-webhook
         spec:
@@ -7970,7 +7970,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: pre-process
         spec:
@@ -8066,7 +8066,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: process
         spec:
@@ -8162,7 +8162,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: queue
         spec:
@@ -8258,7 +8258,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: summary-client
         spec:
@@ -8354,7 +8354,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 7ee2cccd874a14d3ea83eacce7a9e0c15d7e934402b5cc48514f4c0fe770a106
+            config-hash: 05f8bedc2c13172efaffcda4b9ec677993b7ed4ee0f7ab793c260414c4ed6b74
           labels:
             app: upload
         spec:
@@ -8451,7 +8451,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: groundx-service
         spec:
@@ -8593,7 +8593,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: layout-webhook
         spec:
@@ -8707,7 +8707,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: pre-process
         spec:
@@ -8805,7 +8805,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: process
         spec:
@@ -8903,7 +8903,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: queue
         spec:
@@ -9001,7 +9001,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: summary-client
         spec:
@@ -9099,7 +9099,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 6e73cd87052308946c05df74f8880d9257b969a531f01cc733a95da2ab3c8401
+            config-hash: d4d4f2a8f13e835d70845ea31d819cfa8c2d7edbc35b0ac935eb00ce37a31c4d
           labels:
             app: upload
         spec:

--- a/src/groundx/tests/__snapshot__/inference_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/inference_test.yaml.snap
@@ -287,7 +287,7 @@
       template:
         metadata:
           annotations:
-            config-hash: b0c8193aca6eccd6282f680fa67313a44dd0ac24a73ea84906276482bde9c15e
+            config-hash: f67d6c0b16d56b65f28b97d06e08e0aec8d20d7b324a10f6e071a4856bebb1f4
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -1072,7 +1072,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
+            config-hash: 7dcb7a1ab9ac4d7799ca43ec2a1f137237fa1977f3f2230561ba4a952a4ea6f5
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -1855,7 +1855,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d09038b15d81b45a3c91b675dba9421905acbd940eca1349b6af31098c98c043
+            config-hash: 6cb56bdce3ae5cbac499f49f35bcdff7c7738084f55cd3489385a100dd14874d
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -2639,7 +2639,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d09038b15d81b45a3c91b675dba9421905acbd940eca1349b6af31098c98c043
+            config-hash: 6cb56bdce3ae5cbac499f49f35bcdff7c7738084f55cd3489385a100dd14874d
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -3422,7 +3422,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8e63ebfea1c0f60ac40bef43a8944a14369538ba8bb0421a10a4a0be5a804b9e
+            config-hash: e39edcfb8cb84e1324f76f399b4526e6fa20efb448fb13f6e11703b07ce3853c
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -3953,7 +3953,7 @@
       template:
         metadata:
           annotations:
-            config-hash: b9925462022bebe3881e71f27efbc04bb7bfd6e0f9e2e70a62d76cfcc676d69d
+            config-hash: e1f52d4e87b2647506b765c07804a6f3926def037f5ae8e2bbddc96b8a68fef3
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -4744,7 +4744,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 1c478ed103e29a5ca3e1fea4246d3385551c8f60f4141a412bdd8afdfa5115ab
+            config-hash: 0ac0be5132769dab8e511fda8bdc0106793d183e0620921447bf068570d67725
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -5531,7 +5531,7 @@
       template:
         metadata:
           annotations:
-            config-hash: b9925462022bebe3881e71f27efbc04bb7bfd6e0f9e2e70a62d76cfcc676d69d
+            config-hash: e1f52d4e87b2647506b765c07804a6f3926def037f5ae8e2bbddc96b8a68fef3
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
@@ -6038,7 +6038,7 @@
       template:
         metadata:
           annotations:
-            config-hash: db12e6d22be007fc52ee601f6989646694bae2a985f615c39bcfef2d46258a3e
+            config-hash: 6ebf39dc9528dd41fccf3abee945a2ce811738f044edf6b20d571c5a10260076
             config-models-hash: 06ba464c30a765382364510ccee1e65088f7d2acbc11a746b7d14d84c220dd3b
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 8464ec25dcc7b52084949079db8004277a72b0c6d49235247cb01f7d8fde7595
@@ -6742,7 +6742,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
+            config-hash: 7dcb7a1ab9ac4d7799ca43ec2a1f137237fa1977f3f2230561ba4a952a4ea6f5
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
@@ -7373,7 +7373,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10a2c3714245d327a2110a7f94d5a48581c81788dfb36f046ef6276be59e0061
+            config-hash: 7dcb7a1ab9ac4d7799ca43ec2a1f137237fa1977f3f2230561ba4a952a4ea6f5
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:
@@ -7990,7 +7990,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8c8d3d4f45d68a2a23457d8db11374d236b3e1b2f01730bbb2426421e92af4e5
+            config-hash: 6fd688a9c8fd15ff4d418640335dcdec32aa8a95df59c58bbdc85b4c03495ec7
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85
           labels:

--- a/src/groundx/tests/__snapshot__/metrics_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/metrics_test.yaml.snap
@@ -80,7 +80,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 86d1da8da5f72924547d82526efe96059839fc09b4bc09d954f727b101b5de51
+            config-hash: 13762bf6264a5329587da9e9430a9e3938d51fae4bc915bfebae6f8f92e325b2
           labels:
             app: metrics
         spec:
@@ -324,7 +324,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 1daf9029d7dde4fca5766c8975922f88badc65e64fb2c54cba4804d96238797b
+            config-hash: 533cf1cec9200a16333ff2e5bccd926540aa29516ee5b9eb8afe6a6b6dd07f66
           labels:
             app: metrics
         spec:
@@ -568,7 +568,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 806c6c012d288ed7d01ce028871a1fd2ce0f8a6967022c168c565483c51a244c
+            config-hash: e886c66c9a25bbbf899dbd1bb6b3d08e8f6b825ce4df348f61475b1455c6b619
           labels:
             app: metrics
         spec:
@@ -1056,7 +1056,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 806c6c012d288ed7d01ce028871a1fd2ce0f8a6967022c168c565483c51a244c
+            config-hash: e886c66c9a25bbbf899dbd1bb6b3d08e8f6b825ce4df348f61475b1455c6b619
           labels:
             app: metrics
         spec:
@@ -1300,7 +1300,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 10c81a641063ebd4612cf1bd2406640e44dc4efc073389d687733cfee81fefc0
+            config-hash: d71e015e08f240f4971516ee818a0608f5a54fcf2cb17dc0a14e55764d818a18
           labels:
             app: metrics
         spec:
@@ -1544,7 +1544,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 80531d5b33be11826d460361692223598a26633e37e399a28189b87c39c7d5d2
+            config-hash: 961835927bcc71483882ef8285413fefddc48037e576f1e8398cb2fb6c68ae02
           labels:
             app: metrics
         spec:
@@ -1791,7 +1791,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0fbea94469cb86f09136efe02bec5efe29b53188fdfd205f1aaf70f8088a0690
+            config-hash: 8ba50c6277ce29cd5b540af6c86203de6aaad99f53c82147aa82a21765cb7d4d
           labels:
             app: metrics
         spec:
@@ -2035,7 +2035,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 15b2af6dfa5986cb1b2eb13529cf90521cd2db196aee65f04a89a1e7404604b2
+            config-hash: 94047e14ae785d936201fee66607f6fe5efdf28cc7833987e76b5c46e9a4e1ed
           labels:
             app: metrics
         spec:
@@ -2282,7 +2282,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 12d69aae4ef72f8d94f5352201e274f953c1e8fdd2418843cf9b4d1b9febe758
+            config-hash: 51fb61bd52a378ff5211d03c0aa370e27a24a757c278759058f05fb299de4bd9
           labels:
             app: metrics
         spec:
@@ -2526,7 +2526,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 9f6398455179622e31278a0ef6f186c00da6424aebbbf4f11baa22d4189fe321
+            config-hash: fc6d462871de24cb4ab2a637b59043fc315fc3a412518a0bb291ae39ff0205c6
           labels:
             app: metrics
         spec:
@@ -2770,7 +2770,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 9f6398455179622e31278a0ef6f186c00da6424aebbbf4f11baa22d4189fe321
+            config-hash: fc6d462871de24cb4ab2a637b59043fc315fc3a412518a0bb291ae39ff0205c6
           labels:
             app: metrics
         spec:
@@ -3008,7 +3008,7 @@
       template:
         metadata:
           annotations:
-            config-hash: f62066aea9bcfbe8ecd211a9584d49bc5cd491f9ec41e88a19bcb8e82b436761
+            config-hash: 3ae7c41034f03b9f104061736df99b505bdec5af7d5b309cd46f0fad8359e8ca
           labels:
             app: metrics
         spec:

--- a/src/groundx/tests/__snapshot__/ranker_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/ranker_test.yaml.snap
@@ -19,7 +19,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 9e90962567931cc0f6532dd90edf2830e7b83094c61024b09c3152278b67f4ba
+            config-hash: 50ea330b9f5c249403b262295eb7f958761b2513d03caad0ebe4c8a692861b48
             gunicorn-conf-hash: 40212089ebd02f566a0389e71802a4a65d4e823233d849e37148efd96b4b69b3
           labels:
             app: ranker-api
@@ -145,6 +145,7 @@
             deviceType="cuda",
             brokerType="valkey",
             metricsBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="rediss://ranker-cache.existing.com:6380/0",
             searchLog="ranker",
             searchResultBroker="rediss://ranker-cache.existing.com:6380/0",
@@ -183,7 +184,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 9e90962567931cc0f6532dd90edf2830e7b83094c61024b09c3152278b67f4ba
+            config-hash: 50ea330b9f5c249403b262295eb7f958761b2513d03caad0ebe4c8a692861b48
             config-models-hash: 529542d6881ddf622683f3bc8516205a5707660e0a921243b32fd51fd3573f4f
             ldconfig-symlink-hash: 9958a113394211878ece8f9030f4c08a1860e77aa75b5852bfa0691fc3faf32f
             supervisord-hash: 86ea24240aa27a359900fe41482e15acadf7fa84364ebc1698ce533efbfd9c85

--- a/src/groundx/tests/__snapshot__/resources_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/resources_test.yaml.snap
@@ -129,6 +129,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -172,9 +174,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: groundx
@@ -616,6 +615,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
             searchLog="ranker",
             searchResultBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
@@ -1123,6 +1123,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -1175,9 +1177,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: extract-agent
@@ -1814,6 +1813,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="redis://cache-metrics.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
             searchLog="ranker",
             searchResultBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
@@ -2336,6 +2336,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -2379,9 +2381,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: groundx
@@ -2832,6 +2831,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="redis://cache-metrics.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
             searchLog="ranker",
             searchResultBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
@@ -3323,6 +3323,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -3366,9 +3368,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: groundx
@@ -3819,6 +3818,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="redis://cache-metrics.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
             searchLog="ranker",
             searchResultBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
@@ -4322,6 +4322,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
           namespace: eyelevel
           page:
             tokensPerMinute: 1000
@@ -4362,9 +4364,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: groundx
@@ -4817,6 +4816,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="rediss://metrics-cache.existing.com:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="rediss://cache.existing.com:6379/0",
             searchLog="ranker",
             searchResultBroker="rediss://cache.existing.com:6379/0",
@@ -5204,6 +5204,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -5256,9 +5258,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: extract-agent
@@ -5880,6 +5879,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
             searchLog="ranker",
             searchResultBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
@@ -6402,6 +6402,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -6454,9 +6456,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: extract-agent
@@ -7109,6 +7108,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
             searchLog="ranker",
             searchResultBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
@@ -7602,6 +7602,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
           namespace: eyelevel
           page:
             tokensPerMinute: 1000
@@ -7651,9 +7653,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: extract-agent
@@ -8270,6 +8269,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
             searchLog="ranker",
             searchResultBroker="rediss://X.X.X.use2.cache.amazonaws.com:6379/0",
@@ -8667,6 +8667,8 @@
           inference:
             - name: myapp-inference
               tokensPerMinute: 240000
+            - name: myapp-inference
+              busyWindowSeconds: 60
             - name: myapp-api
               tokensPerMinute: 9600
             - name: myapp-inference
@@ -8709,9 +8711,6 @@
               target: my-queue
               threshold: 10
             - name: myapp-save
-              target: my-queue
-              threshold: 10
-            - name: myapp-inference
               target: my-queue
               threshold: 10
           throughput:
@@ -9262,6 +9261,7 @@
             deviceType="cpu",
             brokerType="redis",
             metricsBroker="redis://myapp-myapp.eyelevel.svc.cluster.local:8082/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://myapp.eyelevel.svc.cluster.local:8082/0",
             searchLog="myapp",
             searchResultBroker="redis://myapp.eyelevel.svc.cluster.local:8082/0",
@@ -9646,6 +9646,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -9689,9 +9691,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: groundx
@@ -10116,6 +10115,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="redis://cache-metrics.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
             searchLog="ranker",
             searchResultBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
@@ -10621,6 +10621,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -10664,9 +10666,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: groundx
@@ -11091,6 +11090,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="redis://cache-metrics.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
             searchLog="ranker",
             searchResultBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
@@ -11603,6 +11603,8 @@
           inference:
             - name: layout-inference
               tokensPerMinute: 360000
+            - name: ranker-inference
+              busyWindowSeconds: 60
             - name: summary-api
               tokensPerMinute: 9600
             - name: summary-inference
@@ -11655,9 +11657,6 @@
               threshold: 10
             - name: layout-save
               target: save_queue,celery
-              threshold: 10
-            - name: ranker-inference
-              target: inference_queue
               threshold: 10
           throughput:
             - name: extract-agent
@@ -12266,6 +12265,7 @@
             deviceType="cuda",
             brokerType="redis",
             metricsBroker="redis://cache-metrics.eyelevel.svc.cluster.local:6379/0",
+            metricsBusyWindowSeconds=60,
             searchBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",
             searchLog="ranker",
             searchResultBroker="redis://cache.eyelevel.svc.cluster.local:6379/0",

--- a/src/groundx/tests/ranker_test.yaml
+++ b/src/groundx/tests/ranker_test.yaml
@@ -29,7 +29,7 @@ tests:
           value: 8080
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe.exec
-  - it: "ranker inference HPA uses celery queue backpressure"
+  - it: "ranker inference HPA uses windowed busy metric"
     templates:
       - ../templates/resources/hpa.yaml
     values:
@@ -41,7 +41,6 @@ tests:
       ranker.inference.replicas.min: 1
       ranker.inference.replicas.max: 4
       ranker.inference.replicas.target: 0.7
-      ranker.inference.replicas.threshold: 10
       ranker.inference.replicas.throughput: 60000
       ranker.inference.replicas.cooldown: 450
     documentSelector:
@@ -65,7 +64,7 @@ tests:
           value: ranker-inference:throughput
       - equal:
           path: spec.metrics[1].external.metric.name
-          value: ranker-inference:task
+          value: ranker-inference:inference
       - equal:
           path: spec.behavior.scaleUp.stabilizationWindowSeconds
           value: 450
@@ -78,7 +77,7 @@ tests:
       - equal:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds
           value: 900
-  - it: "ranker inference config uses celery task queue metric"
+  - it: "ranker inference config uses windowed inference busy metric"
     templates:
       - ../templates/resources/config-yaml.yaml
     values:
@@ -88,7 +87,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "(?s)task:\\n(?:\\s+.*\\n)*\\s+- name: ranker-inference\\n\\s+target: inference_queue\\n\\s+threshold: 10"
+          pattern: "(?s)inference:\\n(?:\\s+.*\\n)*\\s+- name: ranker-inference\\n\\s+busyWindowSeconds: 60"
       - notMatchRegex:
           path: data["config.yaml"]
           pattern: "(?s)sessions:\\n(?:\\s+.*\\n)*\\s+ranker-inference:"
@@ -97,11 +96,35 @@ tests:
           pattern: "\\s+session: ranker-inference"
       - notMatchRegex:
           path: data["config.yaml"]
-          pattern: "(?s)inference:\\n(?:\\s+- name: [^\\n]+\\n\\s+tokensPerMinute: [0-9]+\\n)*\\s+- name: ranker-inference\\n\\s+tokensPerMinute:"
+          pattern: "(?m)^  task:\\n(?:^    .*\\n)*^    - name: ranker-inference$"
       - notMatchRegex:
           path: data["config.yaml"]
           pattern: "rankerSession:"
-  - it: "ranker cache override configures ranker metrics task session"
+  - it: "ranker inference busy metric is omitted when HPA is disabled"
+    templates:
+      - ../templates/resources/config-yaml.yaml
+      - ../templates/resources/ranker-config-py.yaml
+      - ../templates/resources/hpa.yaml
+    values:
+      - ./files/values.metadata.yaml
+    set:
+      cluster.hpa: false
+      metrics.enabled: true
+      ranker.inference.replicas.desired: 1
+      ranker.inference.replicas.hpa: false
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?s)inference:\\n(?:\\s+.*\\n)*\\s+- name: myapp-inference\\n\\s+busyWindowSeconds:"
+        template: ../templates/resources/config-yaml.yaml
+      - notMatchRegex:
+          path: data["config.py"]
+          pattern: "metricsBusyWindowSeconds=60"
+        template: ../templates/resources/ranker-config-py.yaml
+      - hasDocuments:
+          count: 0
+        template: ../templates/resources/hpa.yaml
+  - it: "ranker cache override keeps ranker busy metric on metrics session"
     templates:
       - ../templates/resources/config-yaml.yaml
     values:
@@ -113,12 +136,15 @@ tests:
       ranker.cache.port: 6380
       ranker.cache.ssl: true
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["config.yaml"]
           pattern: "(?s)sessions:\\n\\s+ranker-inference:\\n\\s+addr: ranker-cache\\.existing\\.com:6380\\n\\s+notCluster: true\\n\\s+ssl: true"
-      - matchRegex:
+      - notMatchRegex:
           path: data["config.yaml"]
           pattern: "(?s)task:\\n(?:\\s+.*\\n)*\\s+- name: ranker-inference\\n\\s+session: ranker-inference\\n\\s+target: inference_queue\\n\\s+threshold: 10"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?s)inference:\\n(?:\\s+.*\\n)*\\s+- name: ranker-inference\\n\\s+busyWindowSeconds: 60"
   - it: "cache override: ranker config"
     templates:
       - ../templates/resources/ranker-config-py.yaml

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1212,7 +1212,8 @@
               "properties": {
                 "desired": { "type": "integer" },
                 "max": { "type": "integer" },
-                "min": { "type": "integer" }
+                "min": { "type": "integer" },
+                "target": { "type": "number" }
               },
               "required": ["desired"],
               "additionalProperties": false

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1241,6 +1241,7 @@
           "properties": {
             "affinity": { "type": "object" },
             "annotations": { "type": "object" },
+            "busyWindowSeconds": { "type": "integer", "minimum": 1 },
             "containerPort": { "type": "integer" },
             "containerSecurityContext": { "type": "object" },
             "deviceType": { "type": "string" },


### PR DESCRIPTION
## Summary

Changes ranker inference autoscaling from queue backlog to a windowed busy-time inference metric while keeping throughput as the other HPA signal.

## Details

- Renders ranker inference under `metrics.inference` with `busyWindowSeconds: 60`.
- Passes `metricsBusyWindowSeconds` to ranker config only when ranker inference HPA is enabled.
- Removes ranker inference from `metrics.task` and avoids a ranker-specific metrics session.
- Keeps ranker cache overrides on search/Celery brokers while metrics continue using the metrics cache.
- Mirrors changed chart files from `src/groundx` into `helm`.
- Restores snapshot labels required by the chart production gate.

## Validation

- `.build/bin/validate-helm.sh --junit`
- HPA-disabled render probe: no busy config or ranker HPA rendered
- HPA-enabled render probe: `busyWindowSeconds`, `metricsBusyWindowSeconds`, `:inference`, `:throughput`, and target `0.9` rendered
- `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec@1.3.1 validate fix-ranker-inference-hpa-readiness --strict`
- `git diff --check`
