### PR TITLE
Add ranker performance diagnostics switch

### DIFF
--- a/helm/templates/resources/ranker-config-py.yaml
+++ b/helm/templates/resources/ranker-config-py.yaml
@@ -20,6 +20,10 @@ data:
         {{- if ne (include "groundx.ranker.inference.busyWindowSeconds" . | trim) "0" }}
         metricsBusyWindowSeconds={{ include "groundx.ranker.inference.busyWindowSeconds" . }},
         {{- end }}
+        {{- $perf := get (.Values.ranker | default dict) "performance" | default "" -}}
+        {{- if ne (toString $perf) "" }}
+        PERFORMANCE={{ $perf | quote }},
+        {{- end }}
         searchBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},
         searchLog={{ include "groundx.ranker.serviceName" . | quote }},
         searchResultBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1180,6 +1180,7 @@
           },
           "additionalProperties": false
         },
+        "performance": { "type": ["string", "integer", "boolean"] },
         "api": {
           "type": "object",
           "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -294,6 +294,11 @@ queue:
       memory: 128Mi
 
 ranker:
+  # Optional diagnostic logging switch. Empty is off; "1" enables ranker/search
+  # timing logs, and "2" may be used by callers that already emit deeper
+  # PERFORMANCE logs.
+  performance: ""
+
   # Optional ranker-only cache override. When addr is set, ranker API and
   # inference use this cache for searchBroker/searchResultBroker instead of
   # the global cache settings.

--- a/src/groundx/templates/resources/ranker-config-py.yaml
+++ b/src/groundx/templates/resources/ranker-config-py.yaml
@@ -20,6 +20,10 @@ data:
         {{- if ne (include "groundx.ranker.inference.busyWindowSeconds" . | trim) "0" }}
         metricsBusyWindowSeconds={{ include "groundx.ranker.inference.busyWindowSeconds" . }},
         {{- end }}
+        {{- $perf := get (.Values.ranker | default dict) "performance" | default "" -}}
+        {{- if ne (toString $perf) "" }}
+        PERFORMANCE={{ $perf | quote }},
+        {{- end }}
         searchBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},
         searchLog={{ include "groundx.ranker.serviceName" . | quote }},
         searchResultBroker={{ printf "%s://%s:%v/0" (include "groundx.ranker.cache.scheme" .) (include "groundx.ranker.cache.addr" .) (include "groundx.ranker.cache.port" .) | quote }},

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1180,6 +1180,7 @@
           },
           "additionalProperties": false
         },
+        "performance": { "type": ["string", "integer", "boolean"] },
         "api": {
           "type": "object",
           "properties": {

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -294,6 +294,11 @@ queue:
       memory: 128Mi
 
 ranker:
+  # Optional diagnostic logging switch. Empty is off; "1" enables ranker/search
+  # timing logs, and "2" may be used by callers that already emit deeper
+  # PERFORMANCE logs.
+  performance: ""
+
   # Optional ranker-only cache override. When addr is set, ranker API and
   # inference use this cache for searchBroker/searchResultBroker instead of
   # the global cache settings.


### PR DESCRIPTION
## Summary
Adds a ranker.performance values switch that renders PERFORMANCE into ranker config.py for ranker API and inference diagnostics. Empty is off; set it to 1 or 2 to enable existing PERFORMANCE-gated timing logs.

Mirrors the change in src/groundx and helm so the published chart path stays in sync.

## Verification
- helm template groundx src/groundx -f src/groundx/values/minikube/values.yaml --set ranker.performance=1
- helm lint src/groundx --set ranker.performance=1
- helm template groundx helm --set ranker.performance=1
- helm lint helm --set ranker.performance=1
- git diff --check