### PR TITLE
Align extract worker shutdown grace periods

### DIFF
--- a/helm/templates/app/celery.yaml
+++ b/helm/templates/app/celery.yaml
@@ -72,6 +72,8 @@ spec:
     spec:
 {{- if and $rp (hasKey $rp "gracePeriod") }}
       terminationGracePeriodSeconds: {{ get $rp "gracePeriod" }}
+{{- else if eq $mapPrefix "extract" }}
+      terminationGracePeriodSeconds: 900
 {{- end }}
 {{- if $san }}
       serviceAccountName: {{ $san }}

--- a/src/groundx/templates/app/celery.yaml
+++ b/src/groundx/templates/app/celery.yaml
@@ -72,6 +72,8 @@ spec:
     spec:
 {{- if and $rp (hasKey $rp "gracePeriod") }}
       terminationGracePeriodSeconds: {{ get $rp "gracePeriod" }}
+{{- else if eq $mapPrefix "extract" }}
+      terminationGracePeriodSeconds: 900
 {{- end }}
 {{- if $san }}
       serviceAccountName: {{ $san }}

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -792,6 +792,7 @@
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -935,6 +936,7 @@
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -1078,6 +1080,7 @@
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -3805,6 +3808,7 @@
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: existing-service-account
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -3949,6 +3953,7 @@
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: existing-service-account
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -4093,6 +4098,7 @@
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: existing-service-account
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -4915,6 +4921,7 @@
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -5058,6 +5065,7 @@
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -5201,6 +5209,7 @@
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -6004,6 +6013,7 @@
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: existing-service-account
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -6148,6 +6158,7 @@
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: existing-service-account
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -6292,6 +6303,7 @@
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: existing-service-account
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -8949,6 +8961,7 @@
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -9088,6 +9101,7 @@
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node
@@ -9227,6 +9241,7 @@
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          terminationGracePeriodSeconds: 900
           tolerations:
             - effect: NoSchedule
               key: node

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -47,6 +47,70 @@ tests:
       - matchRegex:
           path: data["supervisord.conf"]
           pattern: "stopwaitsecs=870"
+  - it: "extract-agent pod allows supervisor to drain"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 900
+  - it: "extract-download pod allows supervisor to drain"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 900
+  - it: "extract-save pod allows supervisor to drain"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-save
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 900
+  - it: "extract-agent pod honors a custom shutdown budget"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.agent.replicas.gracePeriod: 120
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120
+  - it: "extract-agent supervisor keeps a margin inside a custom shutdown budget"
+    templates:
+      - ../templates/resources/extract-supervisord-conf.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.agent.replicas.gracePeriod: 120
+    documentSelector:
+      path: metadata.name
+      value: extract-agent-supervisord-conf-map
+    asserts:
+      - matchRegex:
+          path: data["supervisord.conf"]
+          pattern: "stopwaitsecs=90"
   - it: "extract-agent deployment drains celery consumers before termination"
     templates:
       - ../templates/app/celery.yaml


### PR DESCRIPTION
## Summary
- default Kubernetes termination grace to 900 seconds for extract Celery workers when no override is set
- preserve explicit per-worker overrides and the supervisor's 30-second shutdown margin
- add rendered-chart regression coverage for agent, download, and save workers

## Why
A production rollout terminated an active extract-save pod after Kubernetes' implicit 30-second grace period while supervisor was configured to wait 870 seconds. The late-acknowledged task was recovered only after the broker visibility timeout, delaying the extraction callback by about 12 minutes.

## Verification
- `helm lint src/groundx`
- `helm template groundx src/groundx -f src/groundx/values/minikube/values.yaml`
- `helm unittest src/groundx`
- hosted values render agent/download/save with 900-second pod grace and 870-second supervisor wait