### PR TITLE
Render extraction queue names into config.py

### DIFF
--- a/helm/templates/resources/extract-config-py.yaml
+++ b/helm/templates/resources/extract-config-py.yaml
@@ -45,6 +45,10 @@ data:
         GroundXSettings,
     )
 
+    agent_queue = {{ include "groundx.extract.agent.queue" . | quote }}
+    download_queue = {{ include "groundx.extract.download.queue" . | quote }}
+    save_queue = {{ include "groundx.extract.save.queue" . | quote }}
+
     agent_settings = AgentSettings(
         {{- if ne $bu "" }}
         api_base={{ $bu | quote }},

--- a/src/groundx/templates/resources/extract-config-py.yaml
+++ b/src/groundx/templates/resources/extract-config-py.yaml
@@ -45,6 +45,10 @@ data:
         GroundXSettings,
     )
 
+    agent_queue = {{ include "groundx.extract.agent.queue" . | quote }}
+    download_queue = {{ include "groundx.extract.download.queue" . | quote }}
+    save_queue = {{ include "groundx.extract.save.queue" . | quote }}
+
     agent_settings = AgentSettings(
         {{- if ne $bu "" }}
         api_base={{ $bu | quote }},

--- a/src/groundx/tests/__snapshot__/api_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/api_test.yaml.snap
@@ -434,7 +434,7 @@
       template:
         metadata:
           annotations:
-            config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
+            config-hash: 6abd0516c76aeaf4d3a1187cd7b55d3da0392b6d7d063d01eb834a8385cb37c7
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api
@@ -2098,7 +2098,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
+            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api
@@ -2675,7 +2675,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
+            config-hash: 777c5b290b4786cccb0997d415ec24e8daf204b1411d8b5ad19ffd1f5621a88d
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api
@@ -3239,7 +3239,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
+            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api
@@ -4855,7 +4855,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
+            config-hash: 8bd8132c2793d70f006504380b6bea53b8f53d1f87eb6c98e9915dc91f7f84b2
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -665,7 +665,7 @@
       template:
         metadata:
           annotations:
-            config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
+            config-hash: 6abd0516c76aeaf4d3a1187cd7b55d3da0392b6d7d063d01eb834a8385cb37c7
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -827,7 +827,7 @@
       template:
         metadata:
           annotations:
-            config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
+            config-hash: 6abd0516c76aeaf4d3a1187cd7b55d3da0392b6d7d063d01eb834a8385cb37c7
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -971,7 +971,7 @@
       template:
         metadata:
           annotations:
-            config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
+            config-hash: 6abd0516c76aeaf4d3a1187cd7b55d3da0392b6d7d063d01eb834a8385cb37c7
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save
@@ -3680,7 +3680,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
+            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -3843,7 +3843,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
+            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -3988,7 +3988,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
+            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save
@@ -4794,7 +4794,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
+            config-hash: 777c5b290b4786cccb0997d415ec24e8daf204b1411d8b5ad19ffd1f5621a88d
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -4956,7 +4956,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
+            config-hash: 777c5b290b4786cccb0997d415ec24e8daf204b1411d8b5ad19ffd1f5621a88d
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -5100,7 +5100,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
+            config-hash: 777c5b290b4786cccb0997d415ec24e8daf204b1411d8b5ad19ffd1f5621a88d
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save
@@ -5885,7 +5885,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
+            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -6048,7 +6048,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
+            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -6193,7 +6193,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
+            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save
@@ -8838,7 +8838,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
+            config-hash: 8bd8132c2793d70f006504380b6bea53b8f53d1f87eb6c98e9915dc91f7f84b2
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -8996,7 +8996,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
+            config-hash: 8bd8132c2793d70f006504380b6bea53b8f53d1f87eb6c98e9915dc91f7f84b2
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -9136,7 +9136,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
+            config-hash: 8bd8132c2793d70f006504380b6bea53b8f53d1f87eb6c98e9915dc91f7f84b2
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save

--- a/src/groundx/tests/__snapshot__/extract_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/extract_test.yaml.snap
@@ -10,6 +10,10 @@
             GroundXSettings,
         )
 
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
+
         agent_settings = AgentSettings(
             image_transport="data_url",
         )
@@ -65,6 +69,10 @@
             ContainerUploadSettings,
             GroundXSettings,
         )
+
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
 
         agent_settings = AgentSettings(
             api_base="http://summary-api.eyelevel.svc.cluster.local",
@@ -124,6 +132,10 @@
             ContainerUploadSettings,
             GroundXSettings,
         )
+
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
 
         agent_settings = AgentSettings(
             image_transport="data_url",

--- a/src/groundx/tests/__snapshot__/resources_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/resources_test.yaml.snap
@@ -1342,6 +1342,10 @@
             GroundXSettings,
         )
 
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
+
         agent_settings = AgentSettings(
             image_transport="data_url",
         )
@@ -5409,6 +5413,10 @@
             GroundXSettings,
         )
 
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
+
         agent_settings = AgentSettings(
             api_base="http://summary-api.eyelevel.svc.cluster.local",
             model_id="google/gemma-3-4b-it",
@@ -6628,6 +6636,10 @@
             GroundXSettings,
         )
 
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
+
         agent_settings = AgentSettings(
             api_base="http://summary-api.eyelevel.svc.cluster.local",
             model_id="google/gemma-3-4b-it",
@@ -7797,6 +7809,10 @@
             ContainerUploadSettings,
             GroundXSettings,
         )
+
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
 
         agent_settings = AgentSettings(
             image_transport="data_url",
@@ -11810,6 +11826,10 @@
             ContainerUploadSettings,
             GroundXSettings,
         )
+
+        agent_queue = "agent_queue"
+        download_queue = "download_queue"
+        save_queue = "save_agents_queue"
 
         agent_settings = AgentSettings(
             image_transport="data_url",

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -171,6 +171,25 @@ tests:
       - matchRegex:
           path: data["config.py"]
           pattern: "image_transport=\"data_url\""
+  - it: "extract config uses the same custom queues as its workers"
+    templates:
+      - ../templates/resources/extract-config-py.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.agent.queue: custom_agent_queue
+      extract.download.queue: custom_download_queue
+      extract.save.queue: custom_save_queue
+    asserts:
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'agent_queue = "custom_agent_queue"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'download_queue = "custom_download_queue"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'save_queue = "custom_save_queue"'
   - it: "extract config renders nested model kwargs as Python objects"
     templates:
       - ../templates/resources/extract-config-py.yaml


### PR DESCRIPTION
## Summary

- Render the existing agent, download, and save queue values into generated `config.py`.
- Keep the published `helm/` mirror aligned with `src/groundx`.
- Prove custom queue values render exactly, so application producers can use the same names as Helm-managed workers.

This adds no queue, worker, HPA, or release behavior. Extra module values are backward compatible with the currently deployed extraction image.

## Verification

- `helm unittest src/groundx`: 155 tests and 813 snapshots passed
- `helm lint src/groundx`
- `helm template src/groundx -f src/groundx/values/minikube/values.yaml`
- source and published template mirror comparison
- `git diff --check`

## Rollout

Merge and deploy this chart change before deploying the Internal Arcadia image that imports these values.