### PR TITLE
feat: configure terminal diagnostics per extract pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,28 @@ extract:
 
 When set, pods use simulated LLM responses instead of external model providers.
 
+## Terminal Extract Diagnostics
+
+Terminal extract diagnostics are disabled by default. Enable the same value on
+the extract API, agent, download, and save pods with:
+
+```yaml
+extract:
+  terminalAgentTraceEnabled: true
+```
+
+Override one pod by setting `extract.api.terminalAgentTraceEnabled`,
+`extract.agent.terminalAgentTraceEnabled`,
+`extract.download.terminalAgentTraceEnabled`, or
+`extract.save.terminalAgentTraceEnabled`. An explicit pod value wins over the
+shared value, including `false`.
+
+Use this only with an Internal Arcadia image that implements the
+[AGE-272 terminal diagnostics contract](https://github.com/eyelevelai/internal-arcadia-agents/pull/101).
+The runtime keeps successful work unchanged, publishes Celery failure callbacks
+before terminal persistence, and applies the rollout's storage, access,
+lifecycle, and failure-budget gates.
+
 # Using GroundX On-Prem
 
 ## Get the API Endpoint

--- a/helm/README.md
+++ b/helm/README.md
@@ -17,3 +17,5 @@ The following table lists the configurable parameters of the GroundX chart and t
 | `admin.username`                            | A UUID that will be associated with the admin account in this deployment        | `00000000-0000-0000-0000-000000000000`|
 | `admin.email`                               | The password associated with the admin account in this deployment               | `support@mycorp.net`                  |
 | `admin.password`                            | The email associated with the admin account in this deployment                  | `password`                            |
+| `extract.terminalAgentTraceEnabled`         | Enables terminal-only private diagnostics for every extract pod                  | `false`                               |
+| `extract.<pod>.terminalAgentTraceEnabled`   | Overrides the shared diagnostic value for api, agent, download, or save           | inherited                             |

--- a/helm/templates/_helpers/app/extract-agent.tpl
+++ b/helm/templates/_helpers/app/extract-agent.tpl
@@ -373,6 +373,7 @@ GROUNDX_AGENT_API_KEY
   "EXTRACT_AGENT_IMAGE_TRANSPORT" (include "groundx.extract.agent.imageTransport" .)
   "EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES" (include "groundx.extract.agent.maxImagePayloadBytes" .)
   "EXTRACT_AGENT_MAX_REQUEST_IMAGES" (include "groundx.extract.agent.maxRequestImages" .)
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "agent"))
 -}}
 {{- $cfg := dict
   "celery"       ("celery_agents")

--- a/helm/templates/_helpers/app/extract-api.tpl
+++ b/helm/templates/_helpers/app/extract-api.tpl
@@ -244,9 +244,13 @@ false
 {{- if ne $apiKey "" -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
+{{- $env := dict
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "api"))
+-}}
 {{- $cfg := dict
   "cfg"          (printf "%s-config-py-map" $svc)
   "dependencies" $dpnd
+  "env"          $env
   "fileDomain"   (include "groundx.extract.file.serviceDependency" .)
   "filePort"     (include "groundx.extract.file.port" .)
   "gunicorn"     (printf "%s-gunicorn-conf-py-map" $svc)

--- a/helm/templates/_helpers/app/extract-download.tpl
+++ b/helm/templates/_helpers/app/extract-download.tpl
@@ -181,9 +181,13 @@ false
 {{- if ne $apiKey "" -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
+{{- $env := dict
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "download"))
+-}}
 {{- $cfg := dict
   "celery"       ("celery_agents")
   "dependencies" $dpnd
+  "env"          $env
   "fileDomain"   (include "groundx.extract.file.serviceDependency" .)
   "filePort"     (include "groundx.extract.file.port" .)
   "image"        (include "groundx.extract.download.image" .)

--- a/helm/templates/_helpers/app/extract-save.tpl
+++ b/helm/templates/_helpers/app/extract-save.tpl
@@ -232,9 +232,13 @@ GCP_CREDENTIALS
 {{- if ne $apiKey "" -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
+{{- $env := dict
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "save"))
+-}}
 {{- $cfg := dict
   "celery"       ("celery_agents")
   "dependencies" $dpnd
+  "env"          $env
   "fileDomain"   (include "groundx.extract.file.serviceDependency" .)
   "filePort"     (include "groundx.extract.file.port" .)
   "image"        (include "groundx.extract.save.image" .)

--- a/helm/templates/_helpers/app/extract.tpl
+++ b/helm/templates/_helpers/app/extract.tpl
@@ -18,6 +18,21 @@
 {{ dig "callbackUrl" (include "groundx.groundx.serviceUrl" .) $in }}
 {{- end }}
 
+{{- define "groundx.extract.terminalAgentTraceEnabled" -}}
+{{- $root := .root -}}
+{{- $podName := .pod -}}
+{{- $extract := $root.Values.extract | default dict -}}
+{{- $pod := get $extract $podName | default dict -}}
+{{- $enabled := false -}}
+{{- if hasKey $extract "terminalAgentTraceEnabled" -}}
+  {{- $enabled = get $extract "terminalAgentTraceEnabled" -}}
+{{- end -}}
+{{- if hasKey $pod "terminalAgentTraceEnabled" -}}
+  {{- $enabled = get $pod "terminalAgentTraceEnabled" -}}
+{{- end -}}
+{{- $enabled | toString -}}
+{{- end }}
+
 {{- define "groundx.extract.serviceUrl" -}}
 {{- $in := .Values.extract | default dict -}}
 {{- $ur := dig "callbackUrl" (include "groundx.groundx.serviceUrl" .) $in -}}

--- a/helm/templates/app/api.yaml
+++ b/helm/templates/app/api.yaml
@@ -14,6 +14,7 @@
 {{- $cachePort := coalesce (get $cache "port") (include "groundx.cache.port" $) -}}
 {{- $csct := get $svcData "containerSecurityContext" -}}
 {{- $dpnd := get $svcData "dependencies" | default dict -}}
+{{- $env := get $svcData "env" | default dict -}}
 {{- $guni := get $svcData "gunicorn" -}}
 {{- $image := get $svcData "image" -}}
 {{- $int := get $svcData "interface" -}}
@@ -120,6 +121,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+{{- range $envName, $envValue := $env }}
+            - name: {{ $envName }}
+              value: {{ $envValue | quote }}
+{{- end }}
 {{- if gt (len $scr) 0 }}
           envFrom:
 {{- range $kk, $vv := $scr }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1663,6 +1663,7 @@
               "minimum": 1
             },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }
           },
@@ -1723,6 +1724,7 @@
             },
             "serviceType": { "type": "string" },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "timeout": { "type": "integer" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }
@@ -1772,6 +1774,7 @@
               "additionalProperties": false
             },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }
           },
@@ -1779,6 +1782,7 @@
           "additionalProperties": false
         },
         "enabled": { "type": "boolean" },
+        "terminalAgentTraceEnabled": { "type": "boolean" },
         "file": {
           "type": "object",
           "properties": {
@@ -1834,6 +1838,7 @@
               "additionalProperties": false
             },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "templateId": { "type": "string" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -426,6 +426,7 @@ workspace:
 
 extract:
   enabled: false
+  terminalAgentTraceEnabled: false
 
   agent:
     enabled: false

--- a/openspec/changes/expose-extract-terminal-agent-trace/design.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/design.md
@@ -58,9 +58,9 @@ The agent helper merges this entry with its existing image-transport variables.
 
 ## Runtime Impact
 
-Every extract process receives the effective value. The current application
-uses the value when creating terminal agent diagnostics. API, download, and save
-do not gain new terminal artifact behavior from this chart-only change.
+Every extract process receives the effective value. Internal Arcadia AGE-272
+owns the matching runtime behavior in the API, agent, download, and save
+terminal failure owners. This chart-only change does not create artifacts.
 
 No success-path logs or artifacts are added. Enabling the value only changes
 behavior in compatible runtime paths that already consume it.
@@ -79,11 +79,19 @@ behavior in compatible runtime paths that already consume it.
 
 ## Rollout
 
-1. Deploy the updated chart with the shared default `false` and verify all four
-   extract workloads remain ready.
-2. Enable the shared value or selected pod overrides through Helm.
-3. Verify the effective environment value in each extract deployment.
-4. Verify a compatible agent image writes one bounded artifact only after a
-   terminal agent failure.
+This plan stops after chart validation and hands deployment to Internal Arcadia
+AGE-272. That rollout must:
+
+1. Verify the processed-layout prefix has encryption, blocked public access,
+   least-privilege access, audit logging, and an effective lifecycle rule.
+2. Prove each stage's bounded artifact and total deadline preserve callback or
+   API response behavior.
+3. Deploy a compatible extract image and this chart with capture disabled.
+4. Verify all four workloads are ready and receive the intended effective
+   setting.
+5. Enable pods through their overrides, then use the shared value only after all
+   four pod paths pass their rollout gates.
+6. Verify successful requests write no terminal artifact. Inspect only natural
+   production failures.
 
 No deployment or chart publication is part of implementation.

--- a/openspec/changes/expose-extract-terminal-agent-trace/design.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/design.md
@@ -84,8 +84,10 @@ AGE-272. That rollout must:
 
 1. Verify the processed-layout prefix has encryption, blocked public access,
    least-privilege access, audit logging, and an effective lifecycle rule.
-2. Prove each stage's bounded artifact and total deadline preserve callback or
-   API response behavior.
+2. Prove API diagnostics add at most one second to a failed response while
+   preserving status and body. Prove Celery stages write no terminal object or
+   processing terminal record while callback publication can retry or requeue
+   the task.
 3. Deploy a compatible extract image and this chart with capture disabled.
 4. Verify all four workloads are ready and receive the intended effective
    setting.

--- a/openspec/changes/expose-extract-terminal-agent-trace/design.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/design.md
@@ -84,10 +84,10 @@ AGE-272. That rollout must:
 
 1. Verify the processed-layout prefix has encryption, blocked public access,
    least-privilege access, audit logging, and an effective lifecycle rule.
-2. Prove API diagnostics add at most one second to a failed response while
-   preserving status and body. Prove Celery stages write no terminal object or
-   processing terminal record while callback publication can retry or requeue
-   the task.
+2. Prove API diagnostics use one best-effort one-second transport budget while
+   preserving status and body, without claiming a hard wall-clock limit. Prove
+   Celery stages write no terminal object or processing terminal record while
+   callback publication can retry or requeue the task.
 3. Deploy a compatible extract image and this chart with capture disabled.
 4. Verify all four workloads are ready and receive the intended effective
    setting.

--- a/openspec/changes/expose-extract-terminal-agent-trace/design.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/design.md
@@ -1,0 +1,89 @@
+# Expose Extract Terminal Agent Trace Design
+
+## Values Contract
+
+The shared value is:
+
+```yaml
+extract:
+  terminalAgentTraceEnabled: false
+```
+
+Each extract pod accepts the same optional override:
+
+```yaml
+extract:
+  terminalAgentTraceEnabled: true
+  api:
+    terminalAgentTraceEnabled: false
+  agent:
+    terminalAgentTraceEnabled: true
+  download:
+    terminalAgentTraceEnabled: false
+  save:
+    terminalAgentTraceEnabled: false
+```
+
+The shared value defaults to `false`. Pod overrides have no chart default, so
+omission means inherit the shared value.
+
+## Precedence
+
+Each pod-specific `.tpl` helper checks whether its pod block contains
+`terminalAgentTraceEnabled`:
+
+1. If present, use the pod value.
+2. Otherwise, use `extract.terminalAgentTraceEnabled`.
+3. If the shared value is absent, use `false`.
+
+This must use `hasKey`, not Helm's `coalesce`. Helm treats boolean `false` as
+empty, so plain `coalesce` would incorrectly ignore an explicit pod-level
+`false` when the shared value is `true`.
+
+## Rendering
+
+The API, agent, download, and save settings helpers each add this entry to their
+environment map:
+
+```yaml
+EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED: "true"
+```
+
+The existing Celery deployment template already renders environment maps for
+agent, download, and save. The shared API deployment template will render the
+same settings environment map after `POD_NAME`. Other API services are
+unchanged because their settings do not provide this entry.
+
+The agent helper merges this entry with its existing image-transport variables.
+
+## Runtime Impact
+
+Every extract process receives the effective value. The current application
+uses the value when creating terminal agent diagnostics. API, download, and save
+do not gain new terminal artifact behavior from this chart-only change.
+
+No success-path logs or artifacts are added. Enabling the value only changes
+behavior in compatible runtime paths that already consume it.
+
+## Validation
+
+- Schema accepts booleans at shared and pod scope and rejects other types.
+- Default rendering sets the environment variable to `"false"` on all four
+  extract deployments.
+- Shared `true` renders `"true"` on all four deployments.
+- A pod-level `false` overrides shared `true` only for that pod.
+- A pod-level `true` overrides shared `false` only for that pod.
+- Existing non-extract API snapshots remain functionally unchanged.
+- `.build/bin/validate-helm.sh --junit` passes.
+- Changed chart source files match their `helm/` mirrors.
+
+## Rollout
+
+1. Deploy the updated chart with the shared default `false` and verify all four
+   extract workloads remain ready.
+2. Enable the shared value or selected pod overrides through Helm.
+3. Verify the effective environment value in each extract deployment.
+4. Verify a compatible agent image writes one bounded artifact only after a
+   terminal agent failure.
+
+No deployment or chart publication is part of implementation.

--- a/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
@@ -1,0 +1,52 @@
+# Expose Extract Terminal Agent Trace
+
+## Why
+
+The extract runtime already reads
+`EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED`, but chart users cannot configure it.
+The setting must be available to every extract pod, with one shared default and
+an optional override for each pod.
+
+## Blast Radius
+
+- Changes the pod template for extract API, agent, download, and save
+  deployments.
+- Any changed effective value rolls only the affected extract deployments.
+- Does not add resources, change queues, storage, RBAC, HPA, or stateful data.
+- Runtime behavior still requires an extract image that consumes the environment
+  variable. The current terminal artifact path runs in agent tasks.
+
+## What Changes
+
+- Add shared `extract.terminalAgentTraceEnabled` with default `false`.
+- Add optional `terminalAgentTraceEnabled` overrides under `extract.api`,
+  `extract.agent`, `extract.download`, and `extract.save`.
+- Resolve the effective value inside each pod helper. An explicitly configured
+  pod value wins over the shared value, including explicit `false`.
+- Render the effective value as
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED` in every extract pod.
+- Add environment rendering to the shared API deployment template, matching the
+  existing Celery deployment template.
+- Mirror source chart changes into `helm/`.
+
+## Out Of Scope
+
+- Adding terminal artifact capture to API, download, or save task paths.
+- Adding an arbitrary environment-variable map.
+- Changing the extract application image.
+- Deploying or publishing the chart.
+
+## Affected Environments
+
+Dev, staging, production, and self-hosted clusters are affected only after a
+chart upgrade. There is no data migration or stateful resource impact.
+
+## Rollback / Rollforward
+
+Rollback by setting the shared and pod values to `false`, or by deploying the
+previous chart. Roll forward by deploying the updated chart and enabling the
+shared value or selected pod overrides.
+
+## Open Design Questions
+
+None.

--- a/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
@@ -40,7 +40,10 @@ shared default and an optional override for each pod.
 
 Internal Arcadia AGE-272 owns terminal behavior for API, agent, download, and
 save. The chart is not complete delivery until a compatible extract image uses
-the effective setting in each pod's terminal failure owner.
+the effective setting in each pod's terminal failure owner. API diagnostics use
+one absolute one-second deadline without changing the general request timeout.
+Celery diagnostics are terminal only after callback publication cannot retry or
+requeue the task.
 
 ## Affected Environments
 

--- a/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
@@ -41,7 +41,8 @@ shared default and an optional override for each pod.
 Internal Arcadia AGE-272 owns terminal behavior for API, agent, download, and
 save. The chart is not complete delivery until a compatible extract image uses
 the effective setting in each pod's terminal failure owner. API diagnostics use
-one absolute one-second deadline without changing the general request timeout.
+one best-effort one-second transport budget without changing the general request
+timeout. The storage SDK does not provide a hard wall-clock timeout.
 Celery diagnostics are terminal only after callback publication cannot retry or
 requeue the task.
 

--- a/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/proposal.md
@@ -2,10 +2,10 @@
 
 ## Why
 
-The extract runtime already reads
-`EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED`, but chart users cannot configure it.
-The setting must be available to every extract pod, with one shared default and
-an optional override for each pod.
+The extract runtime uses `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED` to retain
+bounded private evidence after terminal failures, but chart users cannot
+configure it. The setting must be available to every extract pod, with one
+shared default and an optional override for each pod.
 
 ## Blast Radius
 
@@ -13,8 +13,8 @@ an optional override for each pod.
   deployments.
 - Any changed effective value rolls only the affected extract deployments.
 - Does not add resources, change queues, storage, RBAC, HPA, or stateful data.
-- Runtime behavior still requires an extract image that consumes the environment
-  variable. The current terminal artifact path runs in agent tasks.
+- Runtime behavior requires the matching Internal Arcadia AGE-272 extension.
+  The chart change alone only injects configuration.
 
 ## What Changes
 
@@ -31,10 +31,16 @@ an optional override for each pod.
 
 ## Out Of Scope
 
-- Adding terminal artifact capture to API, download, or save task paths.
+- Implementing terminal artifact capture. Internal Arcadia owns that runtime.
 - Adding an arbitrary environment-variable map.
 - Changing the extract application image.
 - Deploying or publishing the chart.
+
+## Runtime Dependency
+
+Internal Arcadia AGE-272 owns terminal behavior for API, agent, download, and
+save. The chart is not complete delivery until a compatible extract image uses
+the effective setting in each pod's terminal failure owner.
 
 ## Affected Environments
 
@@ -44,8 +50,8 @@ chart upgrade. There is no data migration or stateful resource impact.
 ## Rollback / Rollforward
 
 Rollback by setting the shared and pod values to `false`, or by deploying the
-previous chart. Roll forward by deploying the updated chart and enabling the
-shared value or selected pod overrides.
+previous chart. Roll forward only through the Internal Arcadia AGE-272 storage,
+budget, security, readiness, and natural-failure gates.
 
 ## Open Design Questions
 

--- a/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
@@ -85,7 +85,8 @@ diagnostics are safe or active.
 - **THEN** no production capture is enabled by this chart change
 - **AND** deployment remains gated by the Internal Arcadia AGE-272 storage,
   budget, security, readiness, and natural-failure checks
-- **AND** those runtime checks prove API failure diagnostics add at most one
-  second while preserving status and body
+- **AND** those runtime checks prove API failure diagnostics use one best-effort
+  one-second transport budget while preserving status and body, without
+  claiming a hard wall-clock limit
 - **AND** Celery callback retry or requeue retains no terminal artifact or
   processing terminal record.

--- a/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
@@ -73,3 +73,15 @@ changing stateful configuration.
 - **THEN** only the environment of existing extract deployments changes
 - **AND** no service, queue, PVC, RBAC resource, HPA, or stateful resource is
   added or changed.
+
+### Requirement: Runtime rollout remains externally gated
+
+The chart SHALL NOT treat environment rendering as proof that terminal
+diagnostics are safe or active.
+
+#### Scenario: Chart implementation is complete
+
+- **WHEN** chart tests prove the shared and pod values render correctly
+- **THEN** no production capture is enabled by this chart change
+- **AND** deployment remains gated by the Internal Arcadia AGE-272 storage,
+  budget, security, readiness, and natural-failure checks.

--- a/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
@@ -1,0 +1,75 @@
+# Extract Terminal Agent Trace Config Specification
+
+## Purpose
+
+Define how the chart exposes terminal agent tracing to all extract pods through
+a shared default and pod-specific overrides.
+
+## ADDED Requirements
+
+### Requirement: Shared extract setting
+
+The chart SHALL expose `extract.terminalAgentTraceEnabled` as a boolean with a
+default value of `false`.
+
+#### Scenario: Shared setting is omitted
+
+- **GIVEN** the operator omits `extract.terminalAgentTraceEnabled`
+- **WHEN** the chart renders the extract deployments
+- **THEN** every extract pod receives
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED="false"`.
+
+#### Scenario: Shared setting is enabled
+
+- **GIVEN** `extract.terminalAgentTraceEnabled` is `true`
+- **WHEN** the chart renders the extract deployments
+- **THEN** every extract pod receives
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED="true"` unless that pod has an
+  explicit override.
+
+### Requirement: Pod setting takes precedence
+
+The chart SHALL accept optional `terminalAgentTraceEnabled` boolean overrides
+under `extract.api`, `extract.agent`, `extract.download`, and `extract.save`.
+
+#### Scenario: Pod disables shared enabled setting
+
+- **GIVEN** `extract.terminalAgentTraceEnabled` is `true`
+- **AND** `extract.api.terminalAgentTraceEnabled` is `false`
+- **WHEN** the chart renders the extract deployments
+- **THEN** the API pod receives
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED="false"`
+- **AND** the other extract pods receive
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED="true"`.
+
+#### Scenario: Pod enables shared disabled setting
+
+- **GIVEN** `extract.terminalAgentTraceEnabled` is `false`
+- **AND** `extract.agent.terminalAgentTraceEnabled` is `true`
+- **WHEN** the chart renders the extract deployments
+- **THEN** the agent pod receives
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED="true"`
+- **AND** the other extract pods receive
+  `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED="false"`.
+
+### Requirement: Strict schema validation
+
+The chart SHALL accept only boolean values for the shared and pod settings.
+
+#### Scenario: Operator uses a string value
+
+- **GIVEN** any terminal trace setting is the string `"true"`
+- **WHEN** Helm validates the values
+- **THEN** schema validation fails.
+
+### Requirement: Existing deployment topology is preserved
+
+The chart SHALL expose the setting without adding Kubernetes resources or
+changing stateful configuration.
+
+#### Scenario: Terminal trace is enabled
+
+- **WHEN** the chart renders with terminal trace enabled
+- **THEN** only the environment of existing extract deployments changes
+- **AND** no service, queue, PVC, RBAC resource, HPA, or stateful resource is
+  added or changed.

--- a/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/specs/extract-terminal-agent-trace-config/spec.md
@@ -84,4 +84,8 @@ diagnostics are safe or active.
 - **WHEN** chart tests prove the shared and pod values render correctly
 - **THEN** no production capture is enabled by this chart change
 - **AND** deployment remains gated by the Internal Arcadia AGE-272 storage,
-  budget, security, readiness, and natural-failure checks.
+  budget, security, readiness, and natural-failure checks
+- **AND** those runtime checks prove API failure diagnostics add at most one
+  second while preserving status and body
+- **AND** Celery callback retry or requeue retains no terminal artifact or
+  processing terminal record.

--- a/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
@@ -45,6 +45,10 @@
 
 - [ ] Confirm the compatible Internal Arcadia image uses the setting in API,
       agent, download, and save terminal failure owners.
+- [ ] Confirm API failure diagnostics have one absolute one-second deadline and
+      preserve response status and body.
+- [ ] Confirm download, agent, and save write no terminal artifact or processing
+      terminal record while callback publication can retry or requeue the task.
 - [ ] Leave deployment and enablement to the existing AGE-272 storage, budget,
       security, readiness, and natural-failure gates.
 - [ ] Do not deploy or publish from this chart implementation plan.

--- a/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
@@ -45,8 +45,9 @@
 
 - [x] Confirm the compatible Internal Arcadia image uses the setting in API,
       agent, download, and save terminal failure owners.
-- [x] Confirm API failure diagnostics have one absolute one-second deadline and
-      preserve response status and body.
+- [x] Confirm API failure diagnostics use one best-effort one-second transport
+      budget, preserve response status and body, and make no hard wall-clock
+      guarantee.
 - [x] Confirm download, agent, and save write no terminal artifact or processing
       terminal record while callback publication can retry or requeue the task.
 - [x] Leave deployment and enablement to the existing AGE-272 storage, budget,

--- a/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
@@ -2,53 +2,53 @@
 
 ## 1. Values Contract
 
-- [ ] Add the shared default to `src/groundx/values.yaml`.
-- [ ] Add strict shared and pod boolean fields to
+- [x] Add the shared default to `src/groundx/values.yaml`.
+- [x] Add strict shared and pod boolean fields to
       `src/groundx/values.schema.json`.
-- [ ] Do not add pod defaults, because omission means inheritance.
+- [x] Do not add pod defaults, because omission means inheritance.
 
 ## 2. Pod Helpers
 
-- [ ] Add presence-aware effective-value helpers to the API, agent, download,
+- [x] Add presence-aware effective-value helpers to the API, agent, download,
       and save `.tpl` files.
-- [ ] Add the effective environment value to each pod settings map.
-- [ ] Preserve the agent's existing environment entries.
-- [ ] Add settings environment rendering to the shared API deployment template.
+- [x] Add the effective environment value to each pod settings map.
+- [x] Preserve the agent's existing environment entries.
+- [x] Add settings environment rendering to the shared API deployment template.
 
 ## 3. Tests
 
-- [ ] Prove the default is `false` on all four extract deployments.
-- [ ] Prove shared `true` reaches all four deployments.
-- [ ] Prove pod `false` overrides shared `true`.
-- [ ] Prove pod `true` overrides shared `false`.
-- [ ] Prove non-boolean values fail schema validation.
-- [ ] Regenerate snapshots through `helm unittest -u`; do not edit them by hand.
+- [x] Prove the default is `false` on all four extract deployments.
+- [x] Prove shared `true` reaches all four deployments.
+- [x] Prove pod `false` overrides shared `true`.
+- [x] Prove pod `true` overrides shared `false`.
+- [x] Prove non-boolean values fail schema validation.
+- [x] Regenerate snapshots through `helm unittest -u`; do not edit them by hand.
 
 ## 4. Published Mirror
 
-- [ ] Mirror changed source chart files into `helm/`.
-- [ ] Confirm source and mirror files match.
+- [x] Mirror changed source chart files into `helm/`.
+- [x] Confirm source and mirror files match.
 
 ## 5. Documentation
 
-- [ ] Document the shared value, pod overrides, precedence, and default.
-- [ ] Link the compatible Internal Arcadia AGE-272 runtime and rollout contract.
+- [x] Document the shared value, pod overrides, precedence, and default.
+- [x] Link the compatible Internal Arcadia AGE-272 runtime and rollout contract.
 
 ## 6. Validation
 
-- [ ] Run `.build/bin/validate-helm.sh --junit`.
-- [ ] Run strict OpenSpec validation.
-- [ ] Run `git diff --check`.
-- [ ] Review the rendered manifest diff for unrelated changes.
+- [x] Run `.build/bin/validate-helm.sh --junit`.
+- [x] Run strict OpenSpec validation.
+- [x] Run `git diff --check`.
+- [x] Review the rendered manifest diff for unrelated changes.
 
 ## 7. Runtime Handoff
 
-- [ ] Confirm the compatible Internal Arcadia image uses the setting in API,
+- [x] Confirm the compatible Internal Arcadia image uses the setting in API,
       agent, download, and save terminal failure owners.
-- [ ] Confirm API failure diagnostics have one absolute one-second deadline and
+- [x] Confirm API failure diagnostics have one absolute one-second deadline and
       preserve response status and body.
-- [ ] Confirm download, agent, and save write no terminal artifact or processing
+- [x] Confirm download, agent, and save write no terminal artifact or processing
       terminal record while callback publication can retry or requeue the task.
-- [ ] Leave deployment and enablement to the existing AGE-272 storage, budget,
+- [x] Leave deployment and enablement to the existing AGE-272 storage, budget,
       security, readiness, and natural-failure gates.
-- [ ] Do not deploy or publish from this chart implementation plan.
+- [x] Do not deploy or publish from this chart implementation plan.

--- a/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
@@ -1,0 +1,49 @@
+# Expose Extract Terminal Agent Trace Tasks
+
+## 1. Values Contract
+
+- [ ] Add the shared default to `src/groundx/values.yaml`.
+- [ ] Add strict shared and pod boolean fields to
+      `src/groundx/values.schema.json`.
+- [ ] Do not add pod defaults, because omission means inheritance.
+
+## 2. Pod Helpers
+
+- [ ] Add presence-aware effective-value helpers to the API, agent, download,
+      and save `.tpl` files.
+- [ ] Add the effective environment value to each pod settings map.
+- [ ] Preserve the agent's existing environment entries.
+- [ ] Add settings environment rendering to the shared API deployment template.
+
+## 3. Tests
+
+- [ ] Prove the default is `false` on all four extract deployments.
+- [ ] Prove shared `true` reaches all four deployments.
+- [ ] Prove pod `false` overrides shared `true`.
+- [ ] Prove pod `true` overrides shared `false`.
+- [ ] Prove non-boolean values fail schema validation.
+- [ ] Regenerate snapshots through `helm unittest -u`; do not edit them by hand.
+
+## 4. Published Mirror
+
+- [ ] Mirror changed source chart files into `helm/`.
+- [ ] Confirm source and mirror files match.
+
+## 5. Documentation
+
+- [ ] Document the shared value, pod overrides, precedence, and default.
+- [ ] State that only compatible runtime paths act on the setting.
+
+## 6. Validation
+
+- [ ] Run `.build/bin/validate-helm.sh --junit`.
+- [ ] Run strict OpenSpec validation.
+- [ ] Run `git diff --check`.
+- [ ] Review the rendered manifest diff for unrelated changes.
+
+## 7. Rollout
+
+- [ ] Deploy with the shared default `false` and verify all extract workloads.
+- [ ] Enable the shared setting or selected pod overrides through Helm.
+- [ ] Verify each deployment receives its intended effective value.
+- [ ] Verify terminal agent artifact behavior with a compatible extract image.

--- a/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
+++ b/openspec/changes/expose-extract-terminal-agent-trace/tasks.md
@@ -32,7 +32,7 @@
 ## 5. Documentation
 
 - [ ] Document the shared value, pod overrides, precedence, and default.
-- [ ] State that only compatible runtime paths act on the setting.
+- [ ] Link the compatible Internal Arcadia AGE-272 runtime and rollout contract.
 
 ## 6. Validation
 
@@ -41,9 +41,10 @@
 - [ ] Run `git diff --check`.
 - [ ] Review the rendered manifest diff for unrelated changes.
 
-## 7. Rollout
+## 7. Runtime Handoff
 
-- [ ] Deploy with the shared default `false` and verify all extract workloads.
-- [ ] Enable the shared setting or selected pod overrides through Helm.
-- [ ] Verify each deployment receives its intended effective value.
-- [ ] Verify terminal agent artifact behavior with a compatible extract image.
+- [ ] Confirm the compatible Internal Arcadia image uses the setting in API,
+      agent, download, and save terminal failure owners.
+- [ ] Leave deployment and enablement to the existing AGE-272 storage, budget,
+      security, readiness, and natural-failure gates.
+- [ ] Do not deploy or publish from this chart implementation plan.

--- a/src/groundx/templates/_helpers/app/extract-agent.tpl
+++ b/src/groundx/templates/_helpers/app/extract-agent.tpl
@@ -373,6 +373,7 @@ GROUNDX_AGENT_API_KEY
   "EXTRACT_AGENT_IMAGE_TRANSPORT" (include "groundx.extract.agent.imageTransport" .)
   "EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES" (include "groundx.extract.agent.maxImagePayloadBytes" .)
   "EXTRACT_AGENT_MAX_REQUEST_IMAGES" (include "groundx.extract.agent.maxRequestImages" .)
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "agent"))
 -}}
 {{- $cfg := dict
   "celery"       ("celery_agents")

--- a/src/groundx/templates/_helpers/app/extract-api.tpl
+++ b/src/groundx/templates/_helpers/app/extract-api.tpl
@@ -244,9 +244,13 @@ false
 {{- if ne $apiKey "" -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
+{{- $env := dict
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "api"))
+-}}
 {{- $cfg := dict
   "cfg"          (printf "%s-config-py-map" $svc)
   "dependencies" $dpnd
+  "env"          $env
   "fileDomain"   (include "groundx.extract.file.serviceDependency" .)
   "filePort"     (include "groundx.extract.file.port" .)
   "gunicorn"     (printf "%s-gunicorn-conf-py-map" $svc)

--- a/src/groundx/templates/_helpers/app/extract-download.tpl
+++ b/src/groundx/templates/_helpers/app/extract-download.tpl
@@ -181,9 +181,13 @@ false
 {{- if ne $apiKey "" -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
+{{- $env := dict
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "download"))
+-}}
 {{- $cfg := dict
   "celery"       ("celery_agents")
   "dependencies" $dpnd
+  "env"          $env
   "fileDomain"   (include "groundx.extract.file.serviceDependency" .)
   "filePort"     (include "groundx.extract.file.port" .)
   "image"        (include "groundx.extract.download.image" .)

--- a/src/groundx/templates/_helpers/app/extract-save.tpl
+++ b/src/groundx/templates/_helpers/app/extract-save.tpl
@@ -232,9 +232,13 @@ GCP_CREDENTIALS
 {{- if ne $apiKey "" -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
+{{- $env := dict
+  "EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED" (include "groundx.extract.terminalAgentTraceEnabled" (dict "root" . "pod" "save"))
+-}}
 {{- $cfg := dict
   "celery"       ("celery_agents")
   "dependencies" $dpnd
+  "env"          $env
   "fileDomain"   (include "groundx.extract.file.serviceDependency" .)
   "filePort"     (include "groundx.extract.file.port" .)
   "image"        (include "groundx.extract.save.image" .)

--- a/src/groundx/templates/_helpers/app/extract.tpl
+++ b/src/groundx/templates/_helpers/app/extract.tpl
@@ -18,6 +18,21 @@
 {{ dig "callbackUrl" (include "groundx.groundx.serviceUrl" .) $in }}
 {{- end }}
 
+{{- define "groundx.extract.terminalAgentTraceEnabled" -}}
+{{- $root := .root -}}
+{{- $podName := .pod -}}
+{{- $extract := $root.Values.extract | default dict -}}
+{{- $pod := get $extract $podName | default dict -}}
+{{- $enabled := false -}}
+{{- if hasKey $extract "terminalAgentTraceEnabled" -}}
+  {{- $enabled = get $extract "terminalAgentTraceEnabled" -}}
+{{- end -}}
+{{- if hasKey $pod "terminalAgentTraceEnabled" -}}
+  {{- $enabled = get $pod "terminalAgentTraceEnabled" -}}
+{{- end -}}
+{{- $enabled | toString -}}
+{{- end }}
+
 {{- define "groundx.extract.serviceUrl" -}}
 {{- $in := .Values.extract | default dict -}}
 {{- $ur := dig "callbackUrl" (include "groundx.groundx.serviceUrl" .) $in -}}

--- a/src/groundx/templates/app/api.yaml
+++ b/src/groundx/templates/app/api.yaml
@@ -14,6 +14,7 @@
 {{- $cachePort := coalesce (get $cache "port") (include "groundx.cache.port" $) -}}
 {{- $csct := get $svcData "containerSecurityContext" -}}
 {{- $dpnd := get $svcData "dependencies" | default dict -}}
+{{- $env := get $svcData "env" | default dict -}}
 {{- $guni := get $svcData "gunicorn" -}}
 {{- $image := get $svcData "image" -}}
 {{- $int := get $svcData "interface" -}}
@@ -120,6 +121,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+{{- range $envName, $envValue := $env }}
+            - name: {{ $envName }}
+              value: {{ $envValue | quote }}
+{{- end }}
 {{- if gt (len $scr) 0 }}
           envFrom:
 {{- range $kk, $vv := $scr }}

--- a/src/groundx/tests/__snapshot__/api_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/api_test.yaml.snap
@@ -464,6 +464,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -2128,6 +2130,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -2705,6 +2709,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -3269,6 +3275,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -4885,6 +4893,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -695,6 +695,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
                 - name: EXTRACT_AGENT_IMAGE_JPEG_QUALITIES
                   value: "20"
                 - name: EXTRACT_AGENT_IMAGE_MIN_LONG_EDGE_PX
@@ -857,6 +859,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -1001,6 +1005,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -3710,6 +3716,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
                 - name: EXTRACT_AGENT_IMAGE_JPEG_QUALITIES
                   value: "20"
                 - name: EXTRACT_AGENT_IMAGE_MIN_LONG_EDGE_PX
@@ -3873,6 +3881,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -4018,6 +4028,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -4824,6 +4836,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
                 - name: EXTRACT_AGENT_IMAGE_JPEG_QUALITIES
                   value: "20"
                 - name: EXTRACT_AGENT_IMAGE_MIN_LONG_EDGE_PX
@@ -4986,6 +5000,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -5130,6 +5146,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -5915,6 +5933,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
                 - name: EXTRACT_AGENT_IMAGE_JPEG_QUALITIES
                   value: "20"
                 - name: EXTRACT_AGENT_IMAGE_MIN_LONG_EDGE_PX
@@ -6078,6 +6098,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -6223,6 +6245,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -8868,6 +8892,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
                 - name: EXTRACT_AGENT_IMAGE_JPEG_QUALITIES
                   value: "20"
                 - name: EXTRACT_AGENT_IMAGE_MIN_LONG_EDGE_PX
@@ -9026,6 +9052,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -9166,6 +9194,8 @@
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+                  value: "false"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -162,6 +162,160 @@ tests:
           content:
             name: EXTRACT_AGENT_IMAGE_JPEG_QUALITIES
             value: "20"
+  - it: "extract-api receives terminal diagnostics disabled by default"
+    templates:
+      - ../templates/app/api.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: extract-api
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "false"
+  - it: "extract-agent receives the shared terminal diagnostics value"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.terminalAgentTraceEnabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "true"
+  - it: "extract-agent receives terminal diagnostics disabled by default"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "false"
+  - it: "extract-download receives terminal diagnostics disabled by default"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "false"
+  - it: "extract-save receives terminal diagnostics disabled by default"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-save
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "false"
+  - it: "extract-api receives the shared terminal diagnostics value"
+    templates:
+      - ../templates/app/api.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.terminalAgentTraceEnabled: true
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: extract-api
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "true"
+  - it: "extract-download receives the shared terminal diagnostics value"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.terminalAgentTraceEnabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "true"
+  - it: "extract-save receives the shared terminal diagnostics value"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.terminalAgentTraceEnabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-save
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "true"
+  - it: "extract-download explicit false overrides shared true"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.terminalAgentTraceEnabled: true
+      extract.download.terminalAgentTraceEnabled: false
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "false"
+  - it: "extract-save explicit true overrides shared false"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.terminalAgentTraceEnabled: false
+      extract.save.terminalAgentTraceEnabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-save
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED
+            value: "true"
   - it: "extract config passes image transport into SDK agent settings"
     templates:
       - ../templates/resources/extract-config-py.yaml

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1663,6 +1663,7 @@
               "minimum": 1
             },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }
           },
@@ -1723,6 +1724,7 @@
             },
             "serviceType": { "type": "string" },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "timeout": { "type": "integer" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }
@@ -1772,6 +1774,7 @@
               "additionalProperties": false
             },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }
           },
@@ -1779,6 +1782,7 @@
           "additionalProperties": false
         },
         "enabled": { "type": "boolean" },
+        "terminalAgentTraceEnabled": { "type": "boolean" },
         "file": {
           "type": "object",
           "properties": {
@@ -1834,6 +1838,7 @@
               "additionalProperties": false
             },
             "threads": { "type": "integer" },
+            "terminalAgentTraceEnabled": { "type": "boolean" },
             "templateId": { "type": "string" },
             "tolerations": { "type": "array" },
             "workers": { "type": "integer" }

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -426,6 +426,7 @@ workspace:
 
 extract:
   enabled: false
+  terminalAgentTraceEnabled: false
 
   agent:
     enabled: false


### PR DESCRIPTION
## Summary

- Add shared `extract.terminalAgentTraceEnabled`, defaulting to `false`.
- Add optional API, agent, download, and save overrides. An explicit pod value takes precedence over the shared value, including `false`.
- Render `EXTRACTION_TERMINAL_AGENT_TRACE_ENABLED` in all four extract workloads.
- Validate every setting as a boolean and mirror the source chart changes into the published chart.
- Document configuration and rollout requirements.
- Define the API diagnostic timeout as one best-effort one-second transport budget. The storage SDK does not provide a hard wall-clock guarantee.

This PR targets chart version 0.2.7. It requires the compatible Internal Arcadia runtime in eyelevelai/internal-arcadia-agents#101, based on production PR #96. It does not deploy or publish the chart.

## Validation

- Helm unit tests: 11 suites, 165 tests, 813 snapshots passed.
- Source and mirrored chart lint: passed.
- Snapshot labels, workspace chart contract, and storage contract: passed.
- Shared and pod string values are rejected by schema validation.
- Source and mirrored implementation files match.
- Strict OpenSpec validation and `git diff --check`: passed.
