### PR TITLE
Use workload identity for extraction storage

### DIFF
--- a/helm/templates/_helpers/app/extract.tpl
+++ b/helm/templates/_helpers/app/extract.tpl
@@ -61,7 +61,7 @@ false
 {{- define "groundx.extract.file.existing" -}}
 {{- $in := .Values.extract | default dict -}}
 {{- $efs := dig "file" dict $in -}}
-{{- if and (hasKey $efs "password") (hasKey $efs "serviceType") (hasKey $efs "url") (hasKey $efs "username") (hasKey $efs "bucketName") -}}
+{{- if and (hasKey $efs "serviceType") (hasKey $efs "url") (hasKey $efs "bucketName") -}}
 true
 {{- else -}}
 false

--- a/helm/templates/resources/extract-config-py.yaml
+++ b/helm/templates/resources/extract-config-py.yaml
@@ -25,6 +25,8 @@
 {{- $did := include "groundx.extract.save.driveId" . -}}
 {{- $tid := include "groundx.extract.save.templateId" . -}}
 {{- $kw := include "groundx.extract.agent.kwargs" . | fromYaml -}}
+{{- $uploadKey := get $fs "username" | default "" -}}
+{{- $uploadSecret := get $fs "password" | default "" -}}
 {{- if eq $st "s3" }}
 {{- $bucketSuffix = "" -}}
 {{- end }}
@@ -100,8 +102,12 @@ data:
             ssl={{ if eq (printf "%v" (get $fs "bucketSSL")) "true" }}True{{ else }}False{{ end }},
             type={{ $st | quote }},
             url={{ printf "%s://%s/%s" (get $fs "scheme") (get $fs "baseDomain") $bucketSuffix | quote }},
-            key={{ get $fs "username" | quote }},
-            secret={{ get $fs "password" | quote }},
+            {{- if ne $uploadKey "" }}
+            key={{ $uploadKey | quote }},
+            {{- end }}
+            {{- if ne $uploadSecret "" }}
+            secret={{ $uploadSecret | quote }},
+            {{- end }}
         ),
         valid_api_keys=[
         {{- $apiKey := include "groundx.admin.apiKey" . -}}

--- a/src/groundx/templates/_helpers/app/extract.tpl
+++ b/src/groundx/templates/_helpers/app/extract.tpl
@@ -61,7 +61,7 @@ false
 {{- define "groundx.extract.file.existing" -}}
 {{- $in := .Values.extract | default dict -}}
 {{- $efs := dig "file" dict $in -}}
-{{- if and (hasKey $efs "password") (hasKey $efs "serviceType") (hasKey $efs "url") (hasKey $efs "username") (hasKey $efs "bucketName") -}}
+{{- if and (hasKey $efs "serviceType") (hasKey $efs "url") (hasKey $efs "bucketName") -}}
 true
 {{- else -}}
 false

--- a/src/groundx/templates/resources/extract-config-py.yaml
+++ b/src/groundx/templates/resources/extract-config-py.yaml
@@ -25,6 +25,8 @@
 {{- $did := include "groundx.extract.save.driveId" . -}}
 {{- $tid := include "groundx.extract.save.templateId" . -}}
 {{- $kw := include "groundx.extract.agent.kwargs" . | fromYaml -}}
+{{- $uploadKey := get $fs "username" | default "" -}}
+{{- $uploadSecret := get $fs "password" | default "" -}}
 {{- if eq $st "s3" }}
 {{- $bucketSuffix = "" -}}
 {{- end }}
@@ -100,8 +102,12 @@ data:
             ssl={{ if eq (printf "%v" (get $fs "bucketSSL")) "true" }}True{{ else }}False{{ end }},
             type={{ $st | quote }},
             url={{ printf "%s://%s/%s" (get $fs "scheme") (get $fs "baseDomain") $bucketSuffix | quote }},
-            key={{ get $fs "username" | quote }},
-            secret={{ get $fs "password" | quote }},
+            {{- if ne $uploadKey "" }}
+            key={{ $uploadKey | quote }},
+            {{- end }}
+            {{- if ne $uploadSecret "" }}
+            secret={{ $uploadSecret | quote }},
+            {{- end }}
         ),
         valid_api_keys=[
         {{- $apiKey := include "groundx.admin.apiKey" . -}}

--- a/src/groundx/tests/__snapshot__/api_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/api_test.yaml.snap
@@ -2100,7 +2100,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
+            config-hash: 64cf301ad80c10aac44697e39cf327be7d70f37287a3c0918aa2a057f404365a
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api
@@ -3245,7 +3245,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
+            config-hash: 4d0c2cd66dcc5966f925d6a4ebd85318e77cb100c30db9fea164f5b652d3d6c5
             gunicorn-conf-hash: 0b508950537af16f918cc8ca6bdffca604b10a37474c196be4f66081ecc3140b
           labels:
             app: extract-api

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -3686,7 +3686,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
+            config-hash: 64cf301ad80c10aac44697e39cf327be7d70f37287a3c0918aa2a057f404365a
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -3851,7 +3851,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
+            config-hash: 64cf301ad80c10aac44697e39cf327be7d70f37287a3c0918aa2a057f404365a
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -3998,7 +3998,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 06bf95b0ce815466c2a1f202e72eb81c5df9341a915367f38ccbed50bd687212
+            config-hash: 64cf301ad80c10aac44697e39cf327be7d70f37287a3c0918aa2a057f404365a
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save
@@ -5903,7 +5903,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
+            config-hash: 4d0c2cd66dcc5966f925d6a4ebd85318e77cb100c30db9fea164f5b652d3d6c5
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-agent
@@ -6068,7 +6068,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
+            config-hash: 4d0c2cd66dcc5966f925d6a4ebd85318e77cb100c30db9fea164f5b652d3d6c5
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-download
@@ -6215,7 +6215,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 64ee76a5d13130cca78ec39808f64dbc4b6d017989feaf1ba35053458b23727f
+            config-hash: 4d0c2cd66dcc5966f925d6a4ebd85318e77cb100c30db9fea164f5b652d3d6c5
             supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
           labels:
             app: extract-save

--- a/src/groundx/tests/__snapshot__/resources_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/resources_test.yaml.snap
@@ -5437,8 +5437,6 @@
                 ssl=True,
                 type="s3",
                 url="https://X.s3.us-west-2.amazonaws.com/",
-                key="",
-                secret="",
             ),
             valid_api_keys=[
             ],
@@ -7833,8 +7831,6 @@
                 ssl=True,
                 type="s3",
                 url="https://X.s3.us-west-2.amazonaws.com/",
-                key="",
-                secret="",
             ),
             valid_api_keys=[
             ],

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -344,6 +344,51 @@ tests:
       - matchRegex:
           path: data["config.py"]
           pattern: 'save_queue = "custom_save_queue"'
+  - it: "extract config uses credentialless S3 settings for workload identity"
+    templates:
+      - ../templates/resources/extract-config-py.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.file.bucketName: eyelevel-upload
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://upload.groundx.ai
+    asserts:
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'bucket="eyelevel-upload"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'region="us-west-2"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'type="s3"'
+      - notMatchRegex:
+          path: data["config.py"]
+          pattern: '(?m)^\s+key='
+      - notMatchRegex:
+          path: data["config.py"]
+          pattern: '(?m)^\s+secret='
+  - it: "extract config keeps explicit S3 credentials when configured"
+    templates:
+      - ../templates/resources/extract-config-py.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.file.bucketName: eyelevel-upload
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://upload.groundx.ai
+      extract.file.username: configured-key
+      extract.file.password: configured-secret
+    asserts:
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'key="configured-key"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'secret="configured-secret"'
   - it: "extract config renders nested model kwargs as Python objects"
     templates:
       - ../templates/resources/extract-config-py.yaml


### PR DESCRIPTION
Extraction pods can now use S3 workload identity without rendering empty static credentials. The existing explicit-credential path remains supported.\n\nThis is stacked on PR #56 so the production manifest diff contains only the extraction workload identity change.\n\nValidation:\n- 167 Helm tests passed\n- 813 snapshots passed\n- both chart surfaces linted\n- mirror, workspace, storage, schema, snapshot-label, and diff checks passed