### PR TITLE
Raise extract save worker memory limit to 2Gi

### DIFF
--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -1034,7 +1034,7 @@
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -4057,7 +4057,7 @@
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 1
                   memory: 2Gi
@@ -5175,7 +5175,7 @@
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 512Mi
@@ -6274,7 +6274,7 @@
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 1
                   memory: 2Gi
@@ -9223,7 +9223,7 @@
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 1
                   memory: 2Gi

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -494,7 +494,7 @@ extract:
     resources:
       limits:
         cpu: 1
-        memory: 1Gi
+        memory: 2Gi
       requests:
         cpu: 200m
         memory: 512Mi


### PR DESCRIPTION
Terminal save merges of large charge sets (observed: a 224-charge utility bill) exceed the 1Gi limit and the celery worker is OOM-killed mid `save_charges`, failing the whole document with `WorkerLostError` or a lost task. 2Gi matches the extract agent worker's existing limit. Requests are unchanged, so scheduling pressure does not increase.

The gxprod release already runs with this value baked into its release values (revision 274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)