### PR TITLE
Default extract agent request image cap to 25

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -437,7 +437,7 @@ extract:
     jpegQualities:
       - 20
     maxImagePayloadBytes: 41943040
-    maxRequestImages: 30
+    maxRequestImages: 25
 
     replicas:
       desired: 1

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -708,7 +708,7 @@
                 - name: EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES
                   value: "41943040"
                 - name: EXTRACT_AGENT_MAX_REQUEST_IMAGES
-                  value: "30"
+                  value: "25"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -3729,7 +3729,7 @@
                 - name: EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES
                   value: "41943040"
                 - name: EXTRACT_AGENT_MAX_REQUEST_IMAGES
-                  value: "30"
+                  value: "25"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -4849,7 +4849,7 @@
                 - name: EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES
                   value: "41943040"
                 - name: EXTRACT_AGENT_MAX_REQUEST_IMAGES
-                  value: "30"
+                  value: "25"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret
@@ -5946,7 +5946,7 @@
                 - name: EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES
                   value: "41943040"
                 - name: EXTRACT_AGENT_MAX_REQUEST_IMAGES
-                  value: "30"
+                  value: "25"
               envFrom:
                 - secretRef:
                     name: extract-save-secret
@@ -8905,7 +8905,7 @@
                 - name: EXTRACT_AGENT_MAX_IMAGE_PAYLOAD_BYTES
                   value: "41943040"
                 - name: EXTRACT_AGENT_MAX_REQUEST_IMAGES
-                  value: "30"
+                  value: "25"
               envFrom:
                 - secretRef:
                     name: extract-agent-secret

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -264,7 +264,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: EXTRACT_AGENT_MAX_REQUEST_IMAGES
-            value: "30"
+            value: "25"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -437,7 +437,7 @@ extract:
     jpegQualities:
       - 20
     maxImagePayloadBytes: 41943040
-    maxRequestImages: 30
+    maxRequestImages: 25
 
     replicas:
       desired: 1


### PR DESCRIPTION
Sets `extract.agent.maxRequestImages` to 25, matching the production-validated extraction contract (release values ran 25 until a recent deploy dropped it to 6, which failed multi-page statements; prod is back on 25 as of release revision 277). Test expectations updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)