### PR TITLE
Complete workspace ownership rollout record

### DIFF
--- a/openspec/changes/archive/2026-08-17-configure-workspace-ownership-checks/tasks.md
+++ b/openspec/changes/archive/2026-08-17-configure-workspace-ownership-checks/tasks.md
@@ -30,6 +30,7 @@
 
 ## 5. Rollout
 
-- [ ] Deploy the compatible runner image before this chart.
-- [ ] Verify default-on startup before setting the internal environment to false.
-- [ ] Prove rollback to true before production completion.
+- [x] Deploy the compatible runner image before this chart.
+- [x] Verify default-on startup before setting the internal environment to false.
+- [x] Set the internal environment to false and verify every runner process uses it.
+- [x] Record the operator decision to keep ownership checks disabled and not exercise rollback while Workspace is internal-only.


### PR DESCRIPTION
Records the completed compatible runner rollout, the enabled compatibility check, the final disabled state for internal use, and the explicit decision not to exercise rollback.