### PR TITLE
Reserve extraction worker resources by default

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -449,8 +449,8 @@ extract:
       limits:
         memory: 2Gi
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 2
+        memory: 1Gi
 
   api:
     enabled: false
@@ -481,8 +481,8 @@ extract:
         cpu: 1
         memory: 1Gi
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: 1
+        memory: 1Gi
 
   save:
     enabled: false

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -4,6 +4,53 @@ chart:
   version: 0.1.0
 
 tests:
+  - it: "extract-agent defaults reserve resources for concurrency two"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1Gi
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2Gi
+  - it: "extract-download defaults match its existing limits"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.download.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
   - it: "default: extract.ingest"
     templates:
       - ../templates/resources/extract-config-py.yaml

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -449,8 +449,8 @@ extract:
       limits:
         memory: 2Gi
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 2
+        memory: 1Gi
 
   api:
     enabled: false
@@ -481,8 +481,8 @@ extract:
         cpu: 1
         memory: 1Gi
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: 1
+        memory: 1Gi
 
   save:
     enabled: false


### PR DESCRIPTION
## Summary

- Raise `extract-agent` requests to 2 CPU and 1 GiB memory.
- Raise `extract-download` requests to 1 CPU and 1 GiB memory.
- Keep Celery concurrency and existing limits unchanged.
- Add focused Helm tests and sync the published chart mirror.

## Deployment impact

`extract-agent` now requires a node with at least 2 allocatable CPU. The hosted ranker deployment inherits this default, so its CPU node group must be enlarged before this chart is deployed. Otherwise, the agent pod will remain Pending.

## Validation

- `helm unittest src/groundx`, 174 tests and 813 snapshots passed
- `helm lint src/groundx`
- minikube values render
- hosted ranker values render
- `git diff --check`