### PR TITLE
Fit extract-agent requests on 2-vCPU nodes

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -449,7 +449,7 @@ extract:
       limits:
         memory: 2Gi
       requests:
-        cpu: 2
+        cpu: 1400m
         memory: 1Gi
 
   api:

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -4,7 +4,7 @@ chart:
   version: 0.1.0
 
 tests:
-  - it: "extract-agent defaults reserve resources for concurrency two"
+  - it: "extract-agent defaults fit one worker on a two-vCPU node"
     templates:
       - ../templates/app/celery.yaml
     values:
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 2
+          value: 1400m
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 1Gi

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -449,7 +449,7 @@ extract:
       limits:
         memory: 2Gi
       requests:
-        cpu: 2
+        cpu: 1400m
         memory: 1Gi
 
   api:


### PR DESCRIPTION
## Summary

- Set the default `extract-agent` CPU request to `1400m`.
- Keep Celery concurrency, memory, and the absence of a CPU limit unchanged.
- Keep `extract-download` at its existing 1 CPU request and limit.
- Sync the published chart mirror and update the focused Helm test.

## Why

Hosted CPU nodes expose `1930m` allocatable CPU. Required system pods request about `455m`, leaving `1475m` for application pods. A `1400m` request fits one agent while preventing two agents, or an agent and download worker, from sharing a node.

This reduces pod density and may cause the cluster autoscaler to add more nodes of the existing type. It does not require an instance-type change. A cluster with more than `530m` of per-node system requests may need an environment override.

HPA uses external throughput and task metrics, not CPU utilization, so the request change does not suppress scaling. Extraction logic is unchanged, so Arcadia legacy, Arcadia v1, generic v1, and ADP v1 output behavior are unaffected.

## Validation

- `helm unittest src/groundx`, 193 tests and 815 snapshots passed
- `helm lint src/groundx`
- minikube values render
- hosted ranker values render
- source and published resource defaults match
- `git diff --check`