### PR TITLE
fix(build): run helm verifier scripts with python3, fall back to python

### DIFF
--- a/.build/bin/validate-helm.sh
+++ b/.build/bin/validate-helm.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
 
+# Resolve a Python interpreter (the verifier scripts are python3; prefer it, fall back to python).
+# Works whether the host exposes it as python3 or python; fails fast if neither is present.
+PY="$(command -v python3 || command -v python)" || { echo "no python interpreter on PATH (need python3 or python)" >&2; exit 1; }
+
 RUN_JUNIT=0
 
 usage() {
@@ -81,14 +85,14 @@ for chart in src/groundx helm; do
 done
 
 echo "==> Verifying Helm snapshots did not silently drop empty renders"
-python .build/tests/test_verify_helm_snapshots.py
-python .build/bin/verify-helm-snapshots.py
+"${PY}" .build/tests/test_verify_helm_snapshots.py
+"${PY}" .build/bin/verify-helm-snapshots.py
 
 echo "==> Verifying workspace chart contract"
-python .build/bin/verify-workspace-chart.py
+"${PY}" .build/bin/verify-workspace-chart.py
 
 echo "==> Verifying storage contract"
-python .build/bin/verify-storage-contract.py
+"${PY}" .build/bin/verify-storage-contract.py
 
 echo "==> Rendering workspace chart fixtures"
 helm template workspace-contract src/groundx \


### PR DESCRIPTION
## Problem

`.build/bin/validate-helm.sh` invokes its four verifier scripts as `python`:

```
python .build/tests/test_verify_helm_snapshots.py
python .build/bin/verify-helm-snapshots.py
python .build/bin/verify-workspace-chart.py
python .build/bin/verify-storage-contract.py
```

The scripts are python3 (their shebangs are `#!/usr/bin/env python3`). CI passes only because the GitHub `ubuntu` runner happens to provide a `python`. On a host that has `python3` but no bare `python`, the script dies at the first verifier with `python: command not found`, and because it is mid-way through the "Verifying ..." steps the failure reads as if the chart is broken.

Surfaced while running this gate locally via the engineering-context CI-parity pre-push gate (AGE-254).

## Fix

Resolve a Python interpreter once (prefer `python3`, fall back to `python`) and use it for all four calls; fail fast with a clear message if neither exists:

```bash
PY="$(command -v python3 || command -v python)" || { echo "no python interpreter on PATH (need python3 or python)" >&2; exit 1; }
```

Works whether the host exposes it as `python3` or `python`, prefers python3 (which the scripts already declare), and unchanged on the CI runner.

## Verification

- `validate-helm.sh` runs green end to end on a python3-only host (real helm v3.19.0: lint, 136 unittests, 813 snapshots, all verifiers, exit 0).
- Interpreter resolver, all three branches: python3 present → uses python3; only `python` → falls back; neither → clear error, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)