### PR TITLE
Align maxImages engine contract

### DIFF
--- a/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/design.md
+++ b/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/design.md
@@ -1,0 +1,35 @@
+## Context
+
+The chart already renders an optional `engines.default.maxImages` value. The
+application contract changed, but the chart contract still describes the old
+document-summary fallback behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Describe the current engine-wide, opt-in image count limit.
+
+**Non-Goals:**
+
+- No schema, template, chart, application, or deployment change.
+
+## Decisions
+
+Update only the OpenSpec contract. The existing schema and template already
+render explicit positive values and omit missing or `null` values correctly.
+Changing chart behavior would add risk without fixing the documentation gap.
+
+## Risks / Trade-offs
+
+- Stale application images can still implement older behavior. The contract
+  identifies this as application-owned behavior.
+
+## Migration Plan
+
+No rollout, restart, migration, or state change is required. Merge the contract
+with the compatible application release. Rollback restores the previous text.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/proposal.md
+++ b/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The chart contract still describes `maxImages` as a document-summary limit with
+an application fallback. Compatible application images now treat it as an
+optional engine-wide request limit, with no count limit when it is omitted.
+
+## What Changes
+
+- Describe `engines.default.maxImages` as an engine request image limit.
+- State that omission or `null` leaves requests uncapped by image count.
+- Keep the chart schema and rendering unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `doc-summary-image-limit-config`: Align the chart contract with current
+  application behavior.
+
+## Impact
+
+This is documentation only. It changes no chart output, Kubernetes resource,
+deployment, data, or stateful service in any environment. Rollback restores the
+previous wording. Rollforward merges the corrected contract. Open design
+questions: none.

--- a/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/specs/doc-summary-image-limit-config/spec.md
+++ b/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/specs/doc-summary-image-limit-config/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Chart exposes engine maxImages config
+
+The chart SHALL allow operators to configure the maximum image attachments for
+requests using the default application engine.
+
+#### Scenario: Operator sets maxImages
+
+- **GIVEN** values include `engines.default.maxImages: 20`
+- **WHEN** the chart renders application `config.yaml`
+- **THEN** the rendered `engines.default` config contains `maxImages: 20`
+- **AND** a compatible application uses 20 as the image-count limit for
+  requests using that engine.
+
+#### Scenario: Operator omits maxImages
+
+- **GIVEN** values do not include `engines.default.maxImages`
+- **WHEN** the chart renders the default engine config
+- **THEN** the rendered config does not include `maxImages`
+- **AND** a compatible application applies no image-count limit from this
+  field.
+
+#### Scenario: Operator sets maxImages to null
+
+- **GIVEN** values include `engines.default.maxImages: null`
+- **WHEN** the chart renders the default engine config
+- **THEN** the rendered config does not include `maxImages`
+- **AND** a compatible application applies no image-count limit from this
+  field.
+
+## REMOVED Requirements
+
+### Requirement: Chart exposes document summary maxImages config
+
+**Reason:** `maxImages` now follows normal engine precedence for every request
+using the selected engine, and omission no longer invokes an application
+fallback.
+
+**Migration:** Configure a positive `engines.default.maxImages` value when a
+count limit is required.

--- a/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/tasks.md
+++ b/openspec/changes/archive/2026-08-20-clarify-engine-max-images-contract/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Replace the document-summary fallback requirement with the current
+  engine-wide, opt-in `maxImages` behavior.
+- [x] 1.2 Leave schema, templates, chart values, and Kubernetes resources
+  unchanged.
+
+## 2. Validation
+
+- [x] 2.1 Run strict OpenSpec validation.
+- [x] 2.2 Run Helm lint, template rendering, and unit tests.
+- [x] 2.3 Run `git diff --check` and confirm no chart files changed.
+
+## 3. Rollout
+
+- [x] 3.1 Record that no deployment, canary, secret change, migration, or
+  manual operation is required for this documentation-only correction.

--- a/openspec/specs/doc-summary-image-limit-config/spec.md
+++ b/openspec/specs/doc-summary-image-limit-config/spec.md
@@ -1,33 +1,10 @@
 # doc-summary-image-limit-config Specification
 
 ## Purpose
-Document how the chart exposes the application document-summary image limit through strict values-schema validation and config.yaml rendering, while leaving runtime enforcement to compatible application images.
+Document how the chart exposes the application engine image-count limit through
+strict values-schema validation and config.yaml rendering, while leaving runtime
+enforcement to compatible application images.
 ## Requirements
-### Requirement: Chart exposes document summary maxImages config
-
-The chart SHALL allow operators to configure the app's document-summary page
-image limit through the existing engine values surface.
-
-#### Scenario: Operator sets maxImages
-
-- **GIVEN** values include `engines.default.maxImages: 30`
-- **WHEN** the chart renders application `config.yaml`
-- **THEN** the rendered `engines.default` config contains `maxImages: 30`.
-
-#### Scenario: Operator omits maxImages
-
-- **GIVEN** values do not include `engines.default.maxImages`
-- **WHEN** the chart renders the default engine config
-- **THEN** the rendered config does not include `maxImages`
-- **AND** the app runtime default remains responsible for the default limit.
-
-#### Scenario: Operator sets maxImages to null
-
-- **GIVEN** values include `engines.default.maxImages: null`
-- **WHEN** the chart renders the default engine config
-- **THEN** the rendered config does not include `maxImages`
-- **AND** the app runtime default remains responsible for the default limit.
-
 ### Requirement: Schema permits maxImages
 
 The chart SHALL accept `engines.default.maxImages` under strict values schema
@@ -77,3 +54,32 @@ The chart SHALL not claim to enforce image limits by itself.
 - **AND** the deployed app image does not consume that config key
 - **WHEN** a long document is summarized
 - **THEN** the chart alone is not considered a complete fix for FRA-76.
+
+### Requirement: Chart exposes engine maxImages config
+
+The chart SHALL allow operators to configure the maximum image attachments for
+requests using the default application engine.
+
+#### Scenario: Operator sets maxImages
+
+- **GIVEN** values include `engines.default.maxImages: 20`
+- **WHEN** the chart renders application `config.yaml`
+- **THEN** the rendered `engines.default` config contains `maxImages: 20`
+- **AND** a compatible application uses 20 as the image-count limit for
+  requests using that engine.
+
+#### Scenario: Operator omits maxImages
+
+- **GIVEN** values do not include `engines.default.maxImages`
+- **WHEN** the chart renders the default engine config
+- **THEN** the rendered config does not include `maxImages`
+- **AND** a compatible application applies no image-count limit from this
+  field.
+
+#### Scenario: Operator sets maxImages to null
+
+- **GIVEN** values include `engines.default.maxImages: null`
+- **WHEN** the chart renders the default engine config
+- **THEN** the rendered config does not include `maxImages`
+- **AND** a compatible application applies no image-count limit from this
+  field.


### PR DESCRIPTION
## Why

The chart contract says omitted or null `maxImages` uses an application fallback and describes the field as document-summary-only. Compatible application images now treat it as an optional engine-wide request limit.

## Change

- Describe `engines.default.maxImages` as an engine request limit.
- State that omission or null adds no image-count limit.
- Keep chart schema, templates, values, and Kubernetes resources unchanged.

## Evidence

- Strict OpenSpec validation passes.
- Helm lint and template rendering pass.
- Helm unit tests pass: 193 tests and 815 snapshots.
- No chart files changed.

## Impact

Documentation only. No deployment, restart, migration, secret change, or stateful impact.
