### PR TITLE
Configure Bedrock extract provider

### DIFF
--- a/helm/templates/_helpers/app/extract-agent.tpl
+++ b/helm/templates/_helpers/app/extract-agent.tpl
@@ -41,7 +41,7 @@ GROUNDX_AGENT_API_KEY
 {{- $dflt := "" -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if and (eq $ic "true") (not $svcAllowed) -}}
 {{- $dflt = (include "groundx.summary.api.serviceUrl" .) -}}
 {{- end -}}
@@ -131,7 +131,7 @@ GROUNDX_AGENT_API_KEY
 {{- $dflt := lower (dig "modelId" "" $in) | trim -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if and (eq $ic "true") (not $svcAllowed) (eq $dflt "") -}}
 {{- $dflt = (include "groundx.summary.inference.model.name" .) -}}
 {{- end -}}
@@ -146,7 +146,7 @@ GROUNDX_AGENT_API_KEY
 {{- $val := dig "kwargs" dict $in -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if $has -}}
   {{- toYaml $val -}}
 {{- else if and (eq $ic "true") (not $svcAllowed) -}}
@@ -164,7 +164,7 @@ GROUNDX_AGENT_API_KEY
 {{- $val := dig "reasoningEffort" nil $in -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if $has -}}
   {{- toJson $val -}}
 {{- else if and (eq $ic "true") (not $svcAllowed) -}}
@@ -275,7 +275,11 @@ GROUNDX_AGENT_API_KEY
 {{- define "groundx.extract.agent.imageTransport" -}}
 {{- $b := .Values.extract | default dict -}}
 {{- $in := dig "agent" dict $b -}}
+{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
+remote_url
+{{- else -}}
 {{- lower (dig "imageTransport" "data_url" $in | toString) | trim -}}
+{{- end -}}
 {{- end }}
 
 {{- define "groundx.extract.agent.imageTargetLongEdgePx" -}}
@@ -318,6 +322,9 @@ GROUNDX_AGENT_API_KEY
 {{- $maxRequestImages := include "groundx.extract.agent.maxRequestImages" . | int -}}
 {{- if lt $maxRequestImages 1 -}}
   {{- fail "extract.agent.maxRequestImages must be positive" -}}
+{{- end -}}
+{{- if and (eq (include "groundx.extract.agent.serviceType" .) "bedrock") (ne (include "groundx.extract.file.storageType" .) "s3") -}}
+  {{- fail "extract.agent.serviceType bedrock requires AWS S3 file storage" -}}
 {{- end -}}
 {{- range $quality := splitList "," (include "groundx.extract.agent.imageJpegQualities" .) -}}
   {{- $qualityInt := $quality | int -}}

--- a/helm/templates/_helpers/app/extract-agent.tpl
+++ b/helm/templates/_helpers/app/extract-agent.tpl
@@ -385,8 +385,7 @@ GROUNDX_AGENT_API_KEY
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
 {{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
-{{- $serviceType := include "groundx.extract.agent.serviceType" . -}}
-{{- if or (ne $apiKey "") (and (eq $serviceType "bedrock") (eq $existingSecret "true")) -}}
+{{- if or (ne $apiKey "") (eq $existingSecret "true") -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/helm/templates/_helpers/app/extract-agent.tpl
+++ b/helm/templates/_helpers/app/extract-agent.tpl
@@ -28,7 +28,11 @@ false
 {{- define "groundx.extract.agent.apiKey" -}}
 {{- $b := .Values.extract | default dict -}}
 {{- $in := dig "agent" dict $b -}}
+{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
+{{ dig "apiKey" "" $in }}
+{{- else -}}
 {{ dig "apiKey" (include "groundx.admin.apiKey" .) $in }}
+{{- end -}}
 {{- end }}
 
 {{- define "groundx.extract.agent.apiKeyEnv" -}}
@@ -275,11 +279,7 @@ GROUNDX_AGENT_API_KEY
 {{- define "groundx.extract.agent.imageTransport" -}}
 {{- $b := .Values.extract | default dict -}}
 {{- $in := dig "agent" dict $b -}}
-{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
-remote_url
-{{- else -}}
 {{- lower (dig "imageTransport" "data_url" $in | toString) | trim -}}
-{{- end -}}
 {{- end }}
 
 {{- define "groundx.extract.agent.imageTargetLongEdgePx" -}}
@@ -323,8 +323,22 @@ remote_url
 {{- if lt $maxRequestImages 1 -}}
   {{- fail "extract.agent.maxRequestImages must be positive" -}}
 {{- end -}}
-{{- if and (eq (include "groundx.extract.agent.serviceType" .) "bedrock") (ne (include "groundx.extract.file.storageType" .) "s3") -}}
-  {{- fail "extract.agent.serviceType bedrock requires AWS S3 file storage" -}}
+{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
+  {{- if ne (include "groundx.extract.file.storageType" .) "s3" -}}
+    {{- fail "extract.agent.serviceType bedrock requires AWS S3 file storage" -}}
+  {{- end -}}
+  {{- if eq (include "groundx.extract.agent.baseUrl" . | trim) "" -}}
+    {{- fail "extract.agent.serviceType bedrock requires extract.agent.apiBaseUrl" -}}
+  {{- end -}}
+  {{- if eq (include "groundx.extract.agent.modelId" . | trim) "" -}}
+    {{- fail "extract.agent.serviceType bedrock requires extract.agent.modelId" -}}
+  {{- end -}}
+  {{- $apiKey := include "groundx.extract.agent.apiKey" . | trim -}}
+  {{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+  {{- $clusterSecrets := include "groundx.secrets" . | fromYaml | default dict -}}
+  {{- if and (eq $apiKey "") (eq $existingSecret "false") (eq (len $clusterSecrets) 0) -}}
+    {{- fail "extract.agent.serviceType bedrock requires extract.agent.apiKey, extract.agent.existingSecret, or cluster.secrets" -}}
+  {{- end -}}
 {{- end -}}
 {{- range $quality := splitList "," (include "groundx.extract.agent.imageJpegQualities" .) -}}
   {{- $qualityInt := $quality | int -}}
@@ -370,7 +384,9 @@ remote_url
   (include "groundx.extract.save.secretName" .) (include "groundx.extract.save.secretName" .)
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
-{{- if ne $apiKey "" -}}
+{{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+{{- $serviceType := include "groundx.extract.agent.serviceType" . -}}
+{{- if or (ne $apiKey "") (and (eq $serviceType "bedrock") (eq $existingSecret "true")) -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/helm/templates/_helpers/app/extract-download.tpl
+++ b/helm/templates/_helpers/app/extract-download.tpl
@@ -178,7 +178,8 @@ false
   (include "groundx.extract.save.secretName" .) (include "groundx.extract.save.secretName" .)
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
-{{- if ne $apiKey "" -}}
+{{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+{{- if or (ne $apiKey "") (eq $existingSecret "true") -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/helm/templates/_helpers/app/extract-save.tpl
+++ b/helm/templates/_helpers/app/extract-save.tpl
@@ -229,7 +229,8 @@ GCP_CREDENTIALS
   (include "groundx.extract.save.secretName" .) (include "groundx.extract.save.secretName" .)
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
-{{- if ne $apiKey "" -}}
+{{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+{{- if or (ne $apiKey "") (eq $existingSecret "true") -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/helm/templates/_helpers/app/secrets.tpl
+++ b/helm/templates/_helpers/app/secrets.tpl
@@ -4,7 +4,9 @@
 
 {{- $il := include "groundx.extract.agent.create" . -}}
 {{- $es := include "groundx.extract.agent.existingSecret" . -}}
-{{- if and (eq $il "true") (eq $es "false") -}}
+{{- $ak := include "groundx.extract.agent.apiKey" . -}}
+{{- $st := include "groundx.extract.agent.serviceType" . -}}
+{{- if and (eq $il "true") (eq $es "false") (or (ne $st "bedrock") (ne $ak "")) -}}
 {{- $_ := set $svcs "extract.agent" "extract.agent" -}}
 {{- end -}}
 

--- a/helm/templates/resources/extract-config-py.yaml
+++ b/helm/templates/resources/extract-config-py.yaml
@@ -14,6 +14,7 @@
 {{- $ic := include "groundx.extract.create" . -}}
 
 {{- if eq $ic "true" }}
+{{- include "groundx.extract.agent.validateImageSettings" . -}}
 {{- $fs := (include "groundx.extract.file.settings" . | fromYaml) -}}
 {{- $svc := include "groundx.extract.serviceName" . -}}
 {{- $bucketSuffix := printf "%s/" (get $fs "bucketName") -}}
@@ -22,6 +23,7 @@
 {{- $mid := include "groundx.extract.agent.modelId" . -}}
 {{- $re := include "groundx.extract.agent.reasoningEffort" . -}}
 {{- $it := include "groundx.extract.agent.imageTransport" . -}}
+{{- $ast := include "groundx.extract.agent.serviceType" . -}}
 {{- $did := include "groundx.extract.save.driveId" . -}}
 {{- $tid := include "groundx.extract.save.templateId" . -}}
 {{- $kw := include "groundx.extract.agent.kwargs" . | fromYaml -}}
@@ -57,6 +59,9 @@ data:
         model_id={{ $mid | quote }},
         {{- end }}
         image_transport={{ $it | quote }},
+        {{- if eq $ast "bedrock" }}
+        service={{ $ast | quote }},
+        {{- end }}
         {{- if eq $re "null" }}
         reasoning_effort=None,
         {{- else if ne $re "" }}

--- a/src/groundx/templates/_helpers/app/extract-agent.tpl
+++ b/src/groundx/templates/_helpers/app/extract-agent.tpl
@@ -41,7 +41,7 @@ GROUNDX_AGENT_API_KEY
 {{- $dflt := "" -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if and (eq $ic "true") (not $svcAllowed) -}}
 {{- $dflt = (include "groundx.summary.api.serviceUrl" .) -}}
 {{- end -}}
@@ -131,7 +131,7 @@ GROUNDX_AGENT_API_KEY
 {{- $dflt := lower (dig "modelId" "" $in) | trim -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if and (eq $ic "true") (not $svcAllowed) (eq $dflt "") -}}
 {{- $dflt = (include "groundx.summary.inference.model.name" .) -}}
 {{- end -}}
@@ -146,7 +146,7 @@ GROUNDX_AGENT_API_KEY
 {{- $val := dig "kwargs" dict $in -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if $has -}}
   {{- toYaml $val -}}
 {{- else if and (eq $ic "true") (not $svcAllowed) -}}
@@ -164,7 +164,7 @@ GROUNDX_AGENT_API_KEY
 {{- $val := dig "reasoningEffort" nil $in -}}
 {{- $ic := include "groundx.summary.create" . -}}
 {{- $st := include "groundx.extract.agent.serviceType" . -}}
-{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") -}}
+{{- $svcAllowed := or (eq $st "openai") (eq $st "openai-base64") (eq $st "bedrock") -}}
 {{- if $has -}}
   {{- toJson $val -}}
 {{- else if and (eq $ic "true") (not $svcAllowed) -}}
@@ -275,7 +275,11 @@ GROUNDX_AGENT_API_KEY
 {{- define "groundx.extract.agent.imageTransport" -}}
 {{- $b := .Values.extract | default dict -}}
 {{- $in := dig "agent" dict $b -}}
+{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
+remote_url
+{{- else -}}
 {{- lower (dig "imageTransport" "data_url" $in | toString) | trim -}}
+{{- end -}}
 {{- end }}
 
 {{- define "groundx.extract.agent.imageTargetLongEdgePx" -}}
@@ -318,6 +322,9 @@ GROUNDX_AGENT_API_KEY
 {{- $maxRequestImages := include "groundx.extract.agent.maxRequestImages" . | int -}}
 {{- if lt $maxRequestImages 1 -}}
   {{- fail "extract.agent.maxRequestImages must be positive" -}}
+{{- end -}}
+{{- if and (eq (include "groundx.extract.agent.serviceType" .) "bedrock") (ne (include "groundx.extract.file.storageType" .) "s3") -}}
+  {{- fail "extract.agent.serviceType bedrock requires AWS S3 file storage" -}}
 {{- end -}}
 {{- range $quality := splitList "," (include "groundx.extract.agent.imageJpegQualities" .) -}}
   {{- $qualityInt := $quality | int -}}

--- a/src/groundx/templates/_helpers/app/extract-agent.tpl
+++ b/src/groundx/templates/_helpers/app/extract-agent.tpl
@@ -385,8 +385,7 @@ GROUNDX_AGENT_API_KEY
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
 {{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
-{{- $serviceType := include "groundx.extract.agent.serviceType" . -}}
-{{- if or (ne $apiKey "") (and (eq $serviceType "bedrock") (eq $existingSecret "true")) -}}
+{{- if or (ne $apiKey "") (eq $existingSecret "true") -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/src/groundx/templates/_helpers/app/extract-agent.tpl
+++ b/src/groundx/templates/_helpers/app/extract-agent.tpl
@@ -28,7 +28,11 @@ false
 {{- define "groundx.extract.agent.apiKey" -}}
 {{- $b := .Values.extract | default dict -}}
 {{- $in := dig "agent" dict $b -}}
+{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
+{{ dig "apiKey" "" $in }}
+{{- else -}}
 {{ dig "apiKey" (include "groundx.admin.apiKey" .) $in }}
+{{- end -}}
 {{- end }}
 
 {{- define "groundx.extract.agent.apiKeyEnv" -}}
@@ -275,11 +279,7 @@ GROUNDX_AGENT_API_KEY
 {{- define "groundx.extract.agent.imageTransport" -}}
 {{- $b := .Values.extract | default dict -}}
 {{- $in := dig "agent" dict $b -}}
-{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
-remote_url
-{{- else -}}
 {{- lower (dig "imageTransport" "data_url" $in | toString) | trim -}}
-{{- end -}}
 {{- end }}
 
 {{- define "groundx.extract.agent.imageTargetLongEdgePx" -}}
@@ -323,8 +323,22 @@ remote_url
 {{- if lt $maxRequestImages 1 -}}
   {{- fail "extract.agent.maxRequestImages must be positive" -}}
 {{- end -}}
-{{- if and (eq (include "groundx.extract.agent.serviceType" .) "bedrock") (ne (include "groundx.extract.file.storageType" .) "s3") -}}
-  {{- fail "extract.agent.serviceType bedrock requires AWS S3 file storage" -}}
+{{- if eq (include "groundx.extract.agent.serviceType" .) "bedrock" -}}
+  {{- if ne (include "groundx.extract.file.storageType" .) "s3" -}}
+    {{- fail "extract.agent.serviceType bedrock requires AWS S3 file storage" -}}
+  {{- end -}}
+  {{- if eq (include "groundx.extract.agent.baseUrl" . | trim) "" -}}
+    {{- fail "extract.agent.serviceType bedrock requires extract.agent.apiBaseUrl" -}}
+  {{- end -}}
+  {{- if eq (include "groundx.extract.agent.modelId" . | trim) "" -}}
+    {{- fail "extract.agent.serviceType bedrock requires extract.agent.modelId" -}}
+  {{- end -}}
+  {{- $apiKey := include "groundx.extract.agent.apiKey" . | trim -}}
+  {{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+  {{- $clusterSecrets := include "groundx.secrets" . | fromYaml | default dict -}}
+  {{- if and (eq $apiKey "") (eq $existingSecret "false") (eq (len $clusterSecrets) 0) -}}
+    {{- fail "extract.agent.serviceType bedrock requires extract.agent.apiKey, extract.agent.existingSecret, or cluster.secrets" -}}
+  {{- end -}}
 {{- end -}}
 {{- range $quality := splitList "," (include "groundx.extract.agent.imageJpegQualities" .) -}}
   {{- $qualityInt := $quality | int -}}
@@ -370,7 +384,9 @@ remote_url
   (include "groundx.extract.save.secretName" .) (include "groundx.extract.save.secretName" .)
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
-{{- if ne $apiKey "" -}}
+{{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+{{- $serviceType := include "groundx.extract.agent.serviceType" . -}}
+{{- if or (ne $apiKey "") (and (eq $serviceType "bedrock") (eq $existingSecret "true")) -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/src/groundx/templates/_helpers/app/extract-download.tpl
+++ b/src/groundx/templates/_helpers/app/extract-download.tpl
@@ -178,7 +178,8 @@ false
   (include "groundx.extract.save.secretName" .) (include "groundx.extract.save.secretName" .)
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
-{{- if ne $apiKey "" -}}
+{{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+{{- if or (ne $apiKey "") (eq $existingSecret "true") -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/src/groundx/templates/_helpers/app/extract-save.tpl
+++ b/src/groundx/templates/_helpers/app/extract-save.tpl
@@ -229,7 +229,8 @@ GCP_CREDENTIALS
   (include "groundx.extract.save.secretName" .) (include "groundx.extract.save.secretName" .)
 -}}
 {{- $apiKey := include "groundx.extract.agent.apiKey" . -}}
-{{- if ne $apiKey "" -}}
+{{- $existingSecret := include "groundx.extract.agent.existingSecret" . -}}
+{{- if or (ne $apiKey "") (eq $existingSecret "true") -}}
 {{- $_ := set $data (include "groundx.extract.agent.secretName" .) (include "groundx.extract.agent.secretName" .) -}}
 {{- end -}}
 {{- $env := dict

--- a/src/groundx/templates/_helpers/app/secrets.tpl
+++ b/src/groundx/templates/_helpers/app/secrets.tpl
@@ -4,7 +4,9 @@
 
 {{- $il := include "groundx.extract.agent.create" . -}}
 {{- $es := include "groundx.extract.agent.existingSecret" . -}}
-{{- if and (eq $il "true") (eq $es "false") -}}
+{{- $ak := include "groundx.extract.agent.apiKey" . -}}
+{{- $st := include "groundx.extract.agent.serviceType" . -}}
+{{- if and (eq $il "true") (eq $es "false") (or (ne $st "bedrock") (ne $ak "")) -}}
 {{- $_ := set $svcs "extract.agent" "extract.agent" -}}
 {{- end -}}
 

--- a/src/groundx/templates/resources/extract-config-py.yaml
+++ b/src/groundx/templates/resources/extract-config-py.yaml
@@ -14,6 +14,7 @@
 {{- $ic := include "groundx.extract.create" . -}}
 
 {{- if eq $ic "true" }}
+{{- include "groundx.extract.agent.validateImageSettings" . -}}
 {{- $fs := (include "groundx.extract.file.settings" . | fromYaml) -}}
 {{- $svc := include "groundx.extract.serviceName" . -}}
 {{- $bucketSuffix := printf "%s/" (get $fs "bucketName") -}}
@@ -22,6 +23,7 @@
 {{- $mid := include "groundx.extract.agent.modelId" . -}}
 {{- $re := include "groundx.extract.agent.reasoningEffort" . -}}
 {{- $it := include "groundx.extract.agent.imageTransport" . -}}
+{{- $ast := include "groundx.extract.agent.serviceType" . -}}
 {{- $did := include "groundx.extract.save.driveId" . -}}
 {{- $tid := include "groundx.extract.save.templateId" . -}}
 {{- $kw := include "groundx.extract.agent.kwargs" . | fromYaml -}}
@@ -57,6 +59,9 @@ data:
         model_id={{ $mid | quote }},
         {{- end }}
         image_transport={{ $it | quote }},
+        {{- if eq $ast "bedrock" }}
+        service={{ $ast | quote }},
+        {{- end }}
         {{- if eq $re "null" }}
         reasoning_effort=None,
         {{- else if ne $re "" }}

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -495,7 +495,7 @@ tests:
       - matchRegex:
           path: data["config.py"]
           pattern: "image_transport=\"data_url\""
-  - it: "bedrock extract config renders service and S3 transport"
+  - it: "bedrock extract config renders service and preserves configured transport"
     templates:
       - ../templates/resources/extract-config-py.yaml
     values:
@@ -504,6 +504,7 @@ tests:
       extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
       extract.agent.modelId: google.gemma-4-31b
       extract.agent.serviceType: bedrock
+      extract.agent.imageTransport: pil
       extract.file.bucketName: configured-bucket
       extract.file.region: us-west-2
       extract.file.serviceType: s3
@@ -514,7 +515,7 @@ tests:
           pattern: 'service="bedrock"'
       - matchRegex:
           path: data["config.py"]
-          pattern: 'image_transport="remote_url"'
+          pattern: 'image_transport="pil"'
       - matchRegex:
           path: data["config.py"]
           pattern: 'bucket="configured-bucket"'
@@ -533,6 +534,117 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "extract.agent.serviceType bedrock requires AWS S3 file storage"
+  - it: "bedrock extract config requires an endpoint"
+    templates:
+      - ../templates/resources/extract-supervisord-conf.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiKey: bedrock-key
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "extract.agent.serviceType bedrock requires extract.agent.apiBaseUrl"
+  - it: "bedrock extract config requires a model"
+    templates:
+      - ../templates/resources/extract-supervisord-conf.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.apiKey: bedrock-key
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "extract.agent.serviceType bedrock requires extract.agent.modelId"
+  - it: "bedrock extract config requires a Bedrock credential source"
+    templates:
+      - ../templates/resources/extract-supervisord-conf.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      admin.apiKey: groundx-admin-key
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "extract.agent.serviceType bedrock requires extract.agent.apiKey, extract.agent.existingSecret, or cluster.secrets"
+  - it: "bedrock uses the configured cluster secret instead of the admin API key"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      admin.apiKey: groundx-admin-key
+      cluster.secrets[0]: bedrock-credentials
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: bedrock-credentials
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: extract-agent-secret
+  - it: "bedrock uses the configured extract agent secret"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.existingSecret: true
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    documentSelector:
+      path: metadata.name
+      value: extract-agent
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: extract-agent-secret
   - it: "extract config uses the same custom queues as its workers"
     templates:
       - ../templates/resources/extract-config-py.yaml

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -495,6 +495,44 @@ tests:
       - matchRegex:
           path: data["config.py"]
           pattern: "image_transport=\"data_url\""
+  - it: "bedrock extract config renders service and S3 transport"
+    templates:
+      - ../templates/resources/extract-config-py.yaml
+    values:
+      - ../values/extract/values.yaml
+    set:
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    asserts:
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'service="bedrock"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'image_transport="remote_url"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'bucket="configured-bucket"'
+      - matchRegex:
+          path: data["config.py"]
+          pattern: 'type="s3"'
+  - it: "bedrock extract config rejects non-S3 storage"
+    templates:
+      - ../templates/resources/extract-supervisord-conf.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.serviceType: bedrock
+    asserts:
+      - failedTemplate:
+          errorMessage: "extract.agent.serviceType bedrock requires AWS S3 file storage"
   - it: "extract config uses the same custom queues as its workers"
     templates:
       - ../templates/resources/extract-config-py.yaml

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -645,6 +645,58 @@ tests:
           content:
             secretRef:
               name: extract-agent-secret
+  - it: "bedrock provides the configured extract agent secret to the download worker"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.existingSecret: true
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.download.enabled: true
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: extract-agent-secret
+  - it: "bedrock provides the configured extract agent secret to the save worker"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ./files/values.disabled.yaml
+    set:
+      extract.enabled: true
+      extract.agent.enabled: true
+      extract.agent.apiBaseUrl: https://bedrock-mantle.us-west-2.api.aws/openai/v1
+      extract.agent.existingSecret: true
+      extract.agent.modelId: google.gemma-4-31b
+      extract.agent.serviceType: bedrock
+      extract.file.bucketName: configured-bucket
+      extract.file.region: us-west-2
+      extract.file.serviceType: s3
+      extract.file.url: https://configured-bucket.s3.us-west-2.amazonaws.com
+      extract.save.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: extract-save
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: extract-agent-secret
   - it: "extract config uses the same custom queues as its workers"
     templates:
       - ../templates/resources/extract-config-py.yaml


### PR DESCRIPTION
## Summary

- adds `bedrock` to the external extract provider contract
- renders Bedrock service settings and S3 remote URL transport into extract
- rejects Bedrock configuration unless effective file storage is AWS S3
- keeps the GroundX admin key separate from Bedrock provider credentials
- mounts an existing extract-agent credential secret into agent, download, and save workers
- keeps non-Bedrock rendering unchanged
- updates both chart source and distribution mirror

## Release context

- Cashbot #1639 and GroundX Python #76 are merged
- GroundX Python 3.9.14 is published
- Bedrock remains opt-in until the hosted runtime and workflow configuration are deployed

## Validation

- `helm unittest src/groundx`: 202 tests and 815 snapshots passed
- `.build/bin/validate-helm.sh` passed
- minikube chart render passed
- source and mirror templates match
- `git diff --check` passed