### PR TITLE
fix(chart): clarify inert values contract

### DIFF
--- a/.build/bin/validate-helm.sh
+++ b/.build/bin/validate-helm.sh
@@ -149,6 +149,54 @@ for chart in src/groundx helm; do
   done
 done
 
+echo "==> Verifying deprecated compatibility values contract"
+python - <<'PY'
+import json
+from pathlib import Path
+
+for chart in (Path("src/groundx"), Path("helm")):
+    schema = json.loads((chart / "values.schema.json").read_text())
+    cluster = schema["properties"]["cluster"]["properties"]
+    fields = {
+        "cluster.hasMig": cluster["hasMig"],
+        "cluster.tls.existingSecret": cluster["tls"]["properties"]["existingSecret"],
+    }
+    for path, field in fields.items():
+        if field.get("deprecated") is not True:
+            raise SystemExit(f"{chart}: {path} must be marked deprecated")
+        description = field.get("description", "").lower()
+        if "accepted for compatibility" not in description or "does not change rendered resources" not in description:
+            raise SystemExit(f"{chart}: {path} must describe its inert compatibility behavior")
+PY
+
+for chart in src/groundx helm; do
+  if ! diff -q \
+    <(helm template deprecated-values "${chart}") \
+    <(helm template deprecated-values "${chart}" --set cluster.hasMig=true) \
+    >/dev/null; then
+    echo "${chart}: cluster.hasMig must remain an inert compatibility field in 0.2.7." >&2
+    exit 1
+  fi
+  if ! diff -q \
+    <(helm template deprecated-values "${chart}") \
+    <(helm template deprecated-values "${chart}" --set cluster.tls.existingSecret=legacy-tls) \
+    >/dev/null; then
+    echo "${chart}: cluster.tls.existingSecret must remain an inert compatibility field in 0.2.7." >&2
+    exit 1
+  fi
+done
+
+if grep -R -q 'define "groundx\.hasMig"' \
+  src/groundx/templates helm/templates; then
+  echo "The current chart must not retain an unused groundx.hasMig helper." >&2
+  exit 1
+fi
+if grep -R -q '\.Values\.tls\|cluster\.tls\.existingSecret' \
+  src/groundx/templates/NOTES.txt helm/templates/NOTES.txt; then
+  echo "Helm notes must not claim unsupported TLS Secret behavior." >&2
+  exit 1
+fi
+
 echo "==> Verifying Helm snapshots did not silently drop empty renders"
 python .build/tests/test_verify_helm_snapshots.py
 python .build/bin/verify-helm-snapshots.py

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -3,13 +3,4 @@
 
 Release: {{ .Release.Name }}
 Namespace: {{ $ns }}
-Internal TLS:
-{{- if and .Values.tls .Values.tls.existingSecret }}
-  Using secret: {{ .Values.tls.existingSecret }}
-
-  To inspect it:
-    kubectl -n {{ $ns }} get secret {{ .Values.tls.existingSecret }} -o yaml
-{{- else }}
-  No TLS Secret configured by this chart.
-{{ end }}
 =============

--- a/helm/templates/_helpers/main.tpl
+++ b/helm/templates/_helpers/main.tpl
@@ -66,11 +66,6 @@
 {{ .Values.licenseKey | default "" }}
 {{- end }}
 
-{{- define "groundx.hasMig" -}}
-{{- $b := .Values.cluster | default dict -}}
-{{- dig "hasMig" false $b -}}
-{{- end }}
-
 {{- define "groundx.imagePullPolicy" -}}
 {{- $b := .Values.cluster | default dict -}}
 {{- dig "imagePullPolicy" "IfNotPresent" $b -}}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -25,7 +25,11 @@
     "cluster": {
       "type": "object",
       "properties": {
-        "hasMig": { "type": "boolean" },
+        "hasMig": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "Accepted for compatibility in chart 0.2.7; this field does not change rendered resources. Configure GPU resources through each workload's resources field."
+        },
         "hpa": { "type": "boolean" },
         "imagePullPolicy": { "type": "string" },
         "imagePullSecrets": {
@@ -65,7 +69,11 @@
         "tls": {
           "type": "object",
           "properties": {
-            "existingSecret": { "type": "string" }
+            "existingSecret": {
+              "type": "string",
+              "deprecated": true,
+              "description": "Accepted for compatibility in chart 0.2.7; this field does not change rendered resources or mount a Secret. Use each service's supported ingress.tls list for ingress TLS."
+            }
           },
           "additionalProperties": false
         },

--- a/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/design.md
+++ b/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`cluster.hasMig` and `cluster.tls.existingSecret` entered the strict values schema during an older chart reorganization. The Helm chart never connected them to current templates. `groundx.hasMig` is an unused helper, and `NOTES.txt` instead reads a different top-level TLS path that the schema rejects.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve 0.2.7 values compatibility while making the no-op behavior explicit.
+- Remove dead or misleading template code.
+- Protect the contract with source-backed render checks on both chart surfaces.
+
+**Non-Goals:**
+
+- Invent a MIG profile from one boolean.
+- Add cluster-wide workload TLS without defined consumers, ports, mounts, or trust stores.
+- Change application images, workload manifests, stateful resources, or live Secrets.
+
+## Decisions
+
+Keep both fields schema-valid and add `deprecated: true` plus a precise description. Removing them would turn previously accepted values into upgrade failures. Implementing them would create undefined deployment behavior.
+
+Remove `groundx.hasMig` because no current template calls it. Remove the Internal TLS section from `NOTES.txt` because neither the schema-valid field nor its incorrect top-level alias is consumed.
+
+Extend `.build/bin/validate-helm.sh` rather than add a second test entrypoint. The production gate will parse both schemas, compare default renders with each deprecated field set, reject a reintroduced helper or TLS note, and continue running the existing lint, unit, and render checks.
+
+No ADR is needed. This records existing behavior and compatibility rather than introducing an architectural contract.
+
+## Risks / Trade-offs
+
+- The fields remain accepted, so a deployer using only Helm output will not receive a runtime warning. Mitigation: schema tooling exposes deprecation metadata, operator guidance stops recommending the fields, and the next breaking chart version can remove them.
+- Render equivalence intentionally freezes these fields as inert in 0.2.7. Mitigation: a future implementation must deliberately update the spec and contract test.
+- `helm/` is a manual mirror. Mitigation: the production gate validates both chart surfaces.
+
+## Migration Plan
+
+Ship the source and mirror changes together. No environment redeploy, data migration, Secret rotation, or stateful rollout is required. Roll back by reverting the chart metadata, helper, note, and gate changes. Roll forward by removing the deprecated fields in a future breaking chart release or replacing them with fully specified values.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/proposal.md
+++ b/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The 0.2.7 values schema accepts `cluster.hasMig` and `cluster.tls.existingSecret`, but the current chart does not consume either field. Schema-valid no-op settings can make an operator believe MIG scheduling or cluster-wide TLS is active when rendered resources are unchanged.
+
+## What Changes
+
+- Mark both accepted no-op fields as deprecated and document their actual behavior in the schema.
+- Remove the unused `groundx.hasMig` helper and the Helm note that reads the nonexistent top-level `tls.existingSecret` path.
+- Add executable contract tests proving the fields remain schema-compatible and do not alter rendered manifests.
+- Preserve supported alternatives: explicit per-workload GPU resource and node settings for MIG, per-ingress TLS, and database root certificates.
+- No cluster resources change on upgrade. Dev, staging, and production values remain schema-compatible, and no stateful resource is affected.
+- Rollback is a chart-code revert. Rollforward is the same metadata and test change on the next chart release.
+- Open design questions: none. A boolean does not identify a MIG resource profile, and one Secret name does not define which workloads, ports, or trust stores should use cluster-wide TLS.
+
+## Capabilities
+
+### New Capabilities
+
+- `values-contract-semantics`: Distinguishes accepted compatibility fields from values that change rendered deployment behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `src/groundx/values.schema.json`, helper and note templates, and Helm tests.
+- The manual `helm/` mirror receives the matching schema, helper, and note changes.
+- No application image, Kubernetes API, persisted data, Secret content, or live workload template changes.

--- a/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/specs/values-contract-semantics/spec.md
+++ b/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/specs/values-contract-semantics/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Accepted values distinguish compatibility from behavior
+The chart SHALL keep `cluster.hasMig` and `cluster.tls.existingSecret` schema-valid for 0.2.7 compatibility, SHALL mark both fields deprecated, and SHALL state that neither field changes rendered resources.
+
+#### Scenario: Existing values retain schema compatibility
+- **WHEN** Helm validates values containing either deprecated field
+- **THEN** schema validation succeeds
+- **AND** the schema identifies the field as deprecated and inert
+
+#### Scenario: Deprecated fields do not change manifests
+- **WHEN** the chart is rendered once with default values and once with either deprecated field set
+- **THEN** the Kubernetes manifests are identical
+
+### Requirement: Operator output does not claim unsupported TLS behavior
+The chart SHALL NOT report that a TLS Secret is configured unless a supported template consumes that Secret.
+
+#### Scenario: Helm notes render for the current chart
+- **WHEN** the chart notes are evaluated
+- **THEN** they do not read the nonexistent top-level `tls.existingSecret` path
+- **AND** they do not claim that `cluster.tls.existingSecret` is mounted or used
+
+### Requirement: Published and source chart surfaces agree
+The `src/groundx` source chart and `helm` publication mirror SHALL expose the same deprecation metadata and template behavior for these fields.
+
+#### Scenario: Both chart surfaces are validated
+- **WHEN** the production Helm gate runs
+- **THEN** it validates schema metadata and render equivalence for both chart surfaces

--- a/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/tasks.md
+++ b/openspec/changes/archive/2026-08-20-clarify-values-contract-semantics/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract Tests
+
+- [x] 1.1 Extend the production Helm gate to require deprecation metadata on both chart schemas.
+- [x] 1.2 Add render-equivalence checks for `cluster.hasMig` and `cluster.tls.existingSecret` on both chart surfaces.
+- [x] 1.3 Add static checks that reject the unused MIG helper and misleading TLS note paths.
+
+## 2. Chart Cleanup
+
+- [x] 2.1 Mark the compatibility fields deprecated and inert in `src/groundx/values.schema.json`.
+- [x] 2.2 Remove the unused MIG helper and unsupported TLS note from `src/groundx`.
+- [x] 2.3 Sync the matching schema and template changes into the `helm` publication mirror.
+
+## 3. Validation And Rollout
+
+- [x] 3.1 Run the production Helm gate, Helm lint, unit snapshots, and minikube render.
+- [x] 3.2 Validate and archive the OpenSpec change into the base specification.
+- [x] 3.3 Confirm the diff contains no workload, stateful-resource, Secret-content, or image change. Stage and production require no manual operation or secret rotation.

--- a/openspec/specs/values-contract-semantics/spec.md
+++ b/openspec/specs/values-contract-semantics/spec.md
@@ -1,0 +1,31 @@
+# values-contract-semantics Specification
+
+## Purpose
+Define how schema-valid compatibility fields are represented, tested, and kept consistent across the source and published chart surfaces.
+## Requirements
+### Requirement: Accepted values distinguish compatibility from behavior
+The chart SHALL keep `cluster.hasMig` and `cluster.tls.existingSecret` schema-valid for 0.2.7 compatibility, SHALL mark both fields deprecated, and SHALL state that neither field changes rendered resources.
+
+#### Scenario: Existing values retain schema compatibility
+- **WHEN** Helm validates values containing either deprecated field
+- **THEN** schema validation succeeds
+- **AND** the schema identifies the field as deprecated and inert
+
+#### Scenario: Deprecated fields do not change manifests
+- **WHEN** the chart is rendered once with default values and once with either deprecated field set
+- **THEN** the Kubernetes manifests are identical
+
+### Requirement: Operator output does not claim unsupported TLS behavior
+The chart SHALL NOT report that a TLS Secret is configured unless a supported template consumes that Secret.
+
+#### Scenario: Helm notes render for the current chart
+- **WHEN** the chart notes are evaluated
+- **THEN** they do not read the nonexistent top-level `tls.existingSecret` path
+- **AND** they do not claim that `cluster.tls.existingSecret` is mounted or used
+
+### Requirement: Published and source chart surfaces agree
+The `src/groundx` source chart and `helm` publication mirror SHALL expose the same deprecation metadata and template behavior for these fields.
+
+#### Scenario: Both chart surfaces are validated
+- **WHEN** the production Helm gate runs
+- **THEN** it validates schema metadata and render equivalence for both chart surfaces

--- a/src/groundx/templates/NOTES.txt
+++ b/src/groundx/templates/NOTES.txt
@@ -3,13 +3,4 @@
 
 Release: {{ .Release.Name }}
 Namespace: {{ $ns }}
-Internal TLS:
-{{- if and .Values.tls .Values.tls.existingSecret }}
-  Using secret: {{ .Values.tls.existingSecret }}
-
-  To inspect it:
-    kubectl -n {{ $ns }} get secret {{ .Values.tls.existingSecret }} -o yaml
-{{- else }}
-  No TLS Secret configured by this chart.
-{{ end }}
 =============

--- a/src/groundx/templates/_helpers/main.tpl
+++ b/src/groundx/templates/_helpers/main.tpl
@@ -66,11 +66,6 @@
 {{ .Values.licenseKey | default "" }}
 {{- end }}
 
-{{- define "groundx.hasMig" -}}
-{{- $b := .Values.cluster | default dict -}}
-{{- dig "hasMig" false $b -}}
-{{- end }}
-
 {{- define "groundx.imagePullPolicy" -}}
 {{- $b := .Values.cluster | default dict -}}
 {{- dig "imagePullPolicy" "IfNotPresent" $b -}}

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -25,7 +25,11 @@
     "cluster": {
       "type": "object",
       "properties": {
-        "hasMig": { "type": "boolean" },
+        "hasMig": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "Accepted for compatibility in chart 0.2.7; this field does not change rendered resources. Configure GPU resources through each workload's resources field."
+        },
         "hpa": { "type": "boolean" },
         "imagePullPolicy": { "type": "string" },
         "imagePullSecrets": {
@@ -65,7 +69,11 @@
         "tls": {
           "type": "object",
           "properties": {
-            "existingSecret": { "type": "string" }
+            "existingSecret": {
+              "type": "string",
+              "deprecated": true,
+              "description": "Accepted for compatibility in chart 0.2.7; this field does not change rendered resources or mount a Secret. Use each service's supported ingress.tls list for ingress TLS."
+            }
           },
           "additionalProperties": false
         },


### PR DESCRIPTION
## Why

`cluster.hasMig` and `cluster.tls.existingSecret` are accepted by the strict schema but do not change rendered resources. The chart also retained an unused MIG helper, and its notes read a nonexistent top-level TLS path.

## What changed

- Keep both values schema-valid, mark them deprecated, and describe their no-op behavior.
- Remove the unused MIG helper and false TLS note.
- Verify schema metadata and render equivalence for the source and published chart mirrors.

## Validation

- `bash .build/bin/validate-helm.sh`
- `helm template groundx src/groundx -f src/groundx/values/minikube/values.yaml`
- `helm lint src/groundx`
- `OPENSPEC_TELEMETRY=0 npx @fission-ai/openspec@1.3.1 validate --all --strict --json`

No workload manifests, stateful resources, Secret contents, or live clusters change.