### PR TITLE
feat: add opt-in EKS node diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 
 **[Legacy Terraform Deployment](#legacy-terraform-deployment)**
 - [Accessing Legacy Scripts](#accessing-legacy-scripts)
+- [Optional EKS Node Diagnostics](#optional-eks-node-diagnostics)
 
 # What is GroundX On-Prem?
 
@@ -824,3 +825,9 @@ As of November 4, 2025, we have migrated to a pure helm release deployment. The 
 
 ## Accessing Legacy Scripts
 If you would like to access the legacy terraform scripts, they can be pulled from [legacy-terraform-deployment](https://github.com/eyelevelai/groundx-on-prem/releases/tag/legacy-terraform-deployment).
+
+## Optional EKS Node Diagnostics
+
+Existing AWS EKS deployments still managed by the bundled Terraform can enable
+default-off diagnostics with one setting. See
+[EKS Node Diagnostics](docs/eks-node-diagnostics.md).

--- a/bin/README.md
+++ b/bin/README.md
@@ -15,6 +15,7 @@
     - [Options](#options-1)
     - [Examples](#examples-1)
     - [Customization](#customization)
+  - [bin/eks-node-logs](#bineks-node-logs)
   - [Troubleshooting](#troubleshooting)
 
 The following sections describe the function of a variety of tools and tips which can be used to manage resources within GroundX On-Prem.
@@ -163,6 +164,19 @@ To add new components or modify existing ones, update the following arrays in th
 - `valid_services`
 
 Ensure that the directory structure under the `operator/` folder matches these configurations.
+
+## bin/eks-node-logs
+
+`bin/eks-node-logs` captures one local diagnostic bundle from an exact EKS node
+after the optional Terraform node diagnostics feature is enabled:
+
+```bash
+bin/eks-node-logs --output-dir node-evidence NODE_NAME
+```
+
+It refuses an existing `NodeDiagnostic` and cleans up only the resource UID it
+created. See [EKS Node Diagnostics](../docs/eks-node-diagnostics.md) for
+enablement, permissions, evidence correlation, and unreachable-node limits.
 
 ## Troubleshooting
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -174,9 +174,9 @@ after the optional Terraform node diagnostics feature is enabled:
 bin/eks-node-logs --output-dir node-evidence NODE_NAME
 ```
 
-It refuses an existing `NodeDiagnostic` and cleans up only the resource UID it
-created. See [EKS Node Diagnostics](../docs/eks-node-diagnostics.md) for
-enablement, permissions, evidence correlation, and unreachable-node limits.
+It refuses an existing `NodeDiagnostic` and cleans up only the unchanged
+resource generation it created. See [EKS Node Diagnostics](../docs/eks-node-diagnostics.md)
+for enablement, permissions, evidence correlation, and unreachable-node limits.
 
 ## Troubleshooting
 

--- a/bin/eks-node-logs
+++ b/bin/eks-node-logs
@@ -65,35 +65,89 @@ kubectl get node "$NODE" >/dev/null 2>&1 || fail "node not found: $NODE"
 
 umask 077
 created_uid=""
+created_generation=""
 partial_path=""
+
+clear_ownership() {
+  created_uid=""
+  created_generation=""
+}
 
 delete_owned_capture() {
   [[ -n "$created_uid" ]] || return 0
-
-  local resource_path="/apis/eks.amazonaws.com/v1alpha1/nodediagnostics/$NODE"
-  local delete_options
-  delete_options="{\"apiVersion\":\"v1\",\"kind\":\"DeleteOptions\",\"preconditions\":{\"uid\":\"$created_uid\"}}"
-
-  if printf '%s\n' "$delete_options" |
-    kubectl delete --raw="$resource_path" -f - >/dev/null 2>&1; then
-    created_uid=""
-    return 0
+  if [[ -z "$created_generation" ]]; then
+    warn "could not safely clean up NodeDiagnostic $NODE without its created generation"
+    return 1
   fi
 
-  local current_uid
-  if ! current_uid=$(kubectl get nodediagnostic "$NODE" --ignore-not-found -o 'jsonpath={.metadata.uid}' 2>/dev/null); then
+  local capture
+  if ! capture=$(kubectl get nodediagnostic "$NODE" --ignore-not-found -o json 2>/dev/null); then
     warn "could not verify cleanup for NodeDiagnostic $NODE"
     return 1
   fi
 
-  if [[ -z "$current_uid" ]]; then
-    created_uid=""
+  if [[ -z "$capture" ]]; then
+    clear_ownership
     return 0
   fi
 
+  local identity current_uid current_generation current_resource_version current_destination
+  if ! identity=$(printf '%s' "$capture" | jq -er \
+    '[.metadata.uid, (.metadata.generation | tostring), .metadata.resourceVersion, .spec.logCapture.destination] | @tsv'); then
+    warn "could not verify cleanup identity for NodeDiagnostic $NODE"
+    return 1
+  fi
+  IFS=$'\t' read -r current_uid current_generation current_resource_version current_destination <<<"$identity"
+
   if [[ "$current_uid" != "$created_uid" ]]; then
     warn "NodeDiagnostic $NODE was replaced; leaving the replacement untouched"
-    created_uid=""
+    clear_ownership
+    return 0
+  fi
+
+  if [[ "$current_generation" != "$created_generation" || "$current_destination" != "node" ]]; then
+    warn "NodeDiagnostic $NODE was updated; leaving the updated capture untouched"
+    clear_ownership
+    return 0
+  fi
+
+  local resource_path="/apis/eks.amazonaws.com/v1alpha1/nodediagnostics/$NODE"
+  local delete_options
+  delete_options=$(jq -nc \
+    --arg uid "$created_uid" \
+    --arg resource_version "$current_resource_version" \
+    '{apiVersion:"v1",kind:"DeleteOptions",preconditions:{uid:$uid,resourceVersion:$resource_version}}')
+
+  if printf '%s\n' "$delete_options" |
+    kubectl delete --raw="$resource_path" -f - >/dev/null 2>&1; then
+    clear_ownership
+    return 0
+  fi
+
+  local latest latest_identity latest_uid latest_generation latest_resource_version latest_destination
+  if ! latest=$(kubectl get nodediagnostic "$NODE" --ignore-not-found -o json 2>/dev/null); then
+    warn "could not verify cleanup for NodeDiagnostic $NODE"
+    return 1
+  fi
+
+  if [[ -z "$latest" ]]; then
+    clear_ownership
+    return 0
+  fi
+
+  if ! latest_identity=$(printf '%s' "$latest" | jq -er \
+    '[.metadata.uid, (.metadata.generation | tostring), .metadata.resourceVersion, .spec.logCapture.destination] | @tsv'); then
+    warn "could not verify cleanup identity for NodeDiagnostic $NODE"
+    return 1
+  fi
+  IFS=$'\t' read -r latest_uid latest_generation latest_resource_version latest_destination <<<"$latest_identity"
+
+  if [[ "$latest_uid" != "$created_uid" ||
+        "$latest_generation" != "$created_generation" ||
+        "$latest_destination" != "node" ||
+        "$latest_resource_version" != "$current_resource_version" ]]; then
+    warn "NodeDiagnostic $NODE changed during cleanup; leaving it untouched"
+    clear_ownership
     return 0
   fi
 
@@ -107,11 +161,15 @@ get_owned_capture() {
     fail "NodeDiagnostic $NODE disappeared before capture completed"
   fi
 
-  local current_uid
-  current_uid=$(printf '%s' "$capture" | jq -er '.metadata.uid') ||
-    fail "NodeDiagnostic $NODE did not return a UID"
+  local identity current_uid current_generation current_destination
+  identity=$(printf '%s' "$capture" | jq -er \
+    '[.metadata.uid, (.metadata.generation | tostring), .spec.logCapture.destination] | @tsv') ||
+    fail "NodeDiagnostic $NODE did not return its capture identity"
+  IFS=$'\t' read -r current_uid current_generation current_destination <<<"$identity"
   [[ "$current_uid" == "$created_uid" ]] ||
     fail "NodeDiagnostic $NODE was replaced during capture"
+  [[ "$current_generation" == "$created_generation" && "$current_destination" == "node" ]] ||
+    fail "NodeDiagnostic $NODE was updated during capture"
 
   printf '%s' "$capture"
 }
@@ -145,6 +203,8 @@ EOF
 )
 created_uid=$(printf '%s' "$created" | jq -er '.metadata.uid') ||
   fail "created NodeDiagnostic did not return a UID"
+created_generation=$(printf '%s' "$created" | jq -er '.metadata.generation | tostring') ||
+  fail "created NodeDiagnostic did not return a generation"
 
 echo "Collecting logs from $NODE..."
 kubectl wait \

--- a/bin/eks-node-logs
+++ b/bin/eks-node-logs
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TIMEOUT="300s"
+OUTPUT_DIR="."
+
+usage() {
+  cat <<'EOF'
+Usage: bin/eks-node-logs [--timeout 300s] [--output-dir PATH] NODE
+
+Collect one EKS NodeDiagnostic bundle from the exact node and save it locally.
+EOF
+}
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "Warning: $*" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout)
+      [[ -n "${2:-}" ]] || fail "--timeout requires a value"
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    --output-dir)
+      [[ -n "${2:-}" ]] || fail "--output-dir requires a value"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      [[ -z "${NODE:-}" ]] || fail "provide exactly one node"
+      NODE="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${NODE:-}" ]] || {
+  usage >&2
+  exit 1
+}
+[[ "$TIMEOUT" =~ ^[1-9][0-9]*s$ ]] || fail "timeout must be positive seconds, such as 300s"
+[[ -d "$OUTPUT_DIR" ]] || fail "output directory does not exist: $OUTPUT_DIR"
+
+command -v kubectl >/dev/null 2>&1 || fail "kubectl is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+kubectl get crd nodediagnostics.eks.amazonaws.com >/dev/null 2>&1 ||
+  fail "NodeDiagnostic CRD is unavailable; enable node diagnostics first"
+kubectl get node "$NODE" >/dev/null 2>&1 || fail "node not found: $NODE"
+
+umask 077
+created_uid=""
+partial_path=""
+
+delete_owned_capture() {
+  [[ -n "$created_uid" ]] || return 0
+
+  local resource_path="/apis/eks.amazonaws.com/v1alpha1/nodediagnostics/$NODE"
+  local delete_options
+  delete_options="{\"apiVersion\":\"v1\",\"kind\":\"DeleteOptions\",\"preconditions\":{\"uid\":\"$created_uid\"}}"
+
+  if printf '%s\n' "$delete_options" |
+    kubectl delete --raw="$resource_path" -f - >/dev/null 2>&1; then
+    created_uid=""
+    return 0
+  fi
+
+  local current_uid
+  if ! current_uid=$(kubectl get nodediagnostic "$NODE" --ignore-not-found -o 'jsonpath={.metadata.uid}' 2>/dev/null); then
+    warn "could not verify cleanup for NodeDiagnostic $NODE"
+    return 1
+  fi
+
+  if [[ -z "$current_uid" ]]; then
+    created_uid=""
+    return 0
+  fi
+
+  if [[ "$current_uid" != "$created_uid" ]]; then
+    warn "NodeDiagnostic $NODE was replaced; leaving the replacement untouched"
+    created_uid=""
+    return 0
+  fi
+
+  warn "could not delete the NodeDiagnostic created by this command"
+  return 1
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+
+  if [[ -n "$partial_path" ]]; then
+    rm -f "$partial_path"
+  fi
+
+  if ! delete_owned_capture && [[ $exit_code -eq 0 ]]; then
+    exit_code=1
+  fi
+
+  exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
+
+created=$(cat <<EOF | kubectl create -f - -o json
+apiVersion: eks.amazonaws.com/v1alpha1
+kind: NodeDiagnostic
+metadata:
+  name: $NODE
+spec:
+  logCapture:
+    destination: node
+EOF
+)
+created_uid=$(printf '%s' "$created" | jq -er '.metadata.uid') ||
+  fail "created NodeDiagnostic did not return a UID"
+
+echo "Collecting logs from $NODE..."
+kubectl wait \
+  --for='jsonpath={.status.captureStatuses[0].state.completed}' \
+  "nodediagnostic/$NODE" \
+  --timeout="$TIMEOUT" >/dev/null
+
+reason=$(kubectl get nodediagnostic "$NODE" -o 'jsonpath={.status.captureStatuses[0].state.completed.reason}')
+message=$(kubectl get nodediagnostic "$NODE" -o 'jsonpath={.status.captureStatuses[0].state.completed.message}')
+
+case "$reason" in
+  Success)
+    ;;
+  SuccessWithErrors)
+    warn "capture completed with errors: $message"
+    ;;
+  *)
+    fail "capture failed: ${reason:-unknown} ${message:-}"
+    ;;
+esac
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+output_path="$OUTPUT_DIR/$NODE-$timestamp-logs.tar.gz"
+partial_path="$output_path.partial.$$"
+[[ ! -e "$output_path" ]] || fail "output already exists: $output_path"
+
+kubectl get --raw "/api/v1/nodes/$NODE/proxy/logs/support/$NODE-logs.tar.gz" >"$partial_path"
+[[ -s "$partial_path" ]] || fail "downloaded bundle is empty"
+mv "$partial_path" "$output_path"
+partial_path=""
+
+echo "Saved $output_path"

--- a/bin/eks-node-logs
+++ b/bin/eks-node-logs
@@ -101,6 +101,21 @@ delete_owned_capture() {
   return 1
 }
 
+get_owned_capture() {
+  local capture
+  if ! capture=$(kubectl get nodediagnostic "$NODE" -o json); then
+    fail "NodeDiagnostic $NODE disappeared before capture completed"
+  fi
+
+  local current_uid
+  current_uid=$(printf '%s' "$capture" | jq -er '.metadata.uid') ||
+    fail "NodeDiagnostic $NODE did not return a UID"
+  [[ "$current_uid" == "$created_uid" ]] ||
+    fail "NodeDiagnostic $NODE was replaced during capture"
+
+  printf '%s' "$capture"
+}
+
 cleanup() {
   local exit_code=$?
   trap - EXIT INT TERM
@@ -137,8 +152,9 @@ kubectl wait \
   "nodediagnostic/$NODE" \
   --timeout="$TIMEOUT" >/dev/null
 
-reason=$(kubectl get nodediagnostic "$NODE" -o 'jsonpath={.status.captureStatuses[0].state.completed.reason}')
-message=$(kubectl get nodediagnostic "$NODE" -o 'jsonpath={.status.captureStatuses[0].state.completed.message}')
+capture=$(get_owned_capture)
+reason=$(printf '%s' "$capture" | jq -r '.status.captureStatuses[0].state.completed.reason // empty')
+message=$(printf '%s' "$capture" | jq -r '.status.captureStatuses[0].state.completed.message // empty')
 
 case "$reason" in
   Success)
@@ -157,6 +173,7 @@ partial_path="$output_path.partial.$$"
 [[ ! -e "$output_path" ]] || fail "output already exists: $output_path"
 
 kubectl get --raw "/api/v1/nodes/$NODE/proxy/logs/support/$NODE-logs.tar.gz" >"$partial_path"
+get_owned_capture >/dev/null
 [[ -s "$partial_path" ]] || fail "downloaded bundle is empty"
 mv "$partial_path" "$output_path"
 partial_path=""

--- a/bin/tests/eks-node-logs-test
+++ b/bin/tests/eks-node-logs-test
@@ -33,6 +33,7 @@ run_scenario() {
   ln -s "$FAKE_KUBECTL" "$run_dir/bin/kubectl"
   FAKE_SCENARIO="$scenario" \
     FAKE_KUBECTL_LOG="$run_dir/kubectl.log" \
+    FAKE_KUBECTL_STATE="$run_dir/kubectl.state" \
     PATH="$run_dir/bin:$PATH" \
     "$COMMAND" --output-dir "$run_dir/output" "$NODE" \
     >"$run_dir/stdout" 2>"$run_dir/stderr"
@@ -65,5 +66,21 @@ replacement_log="$TEST_ROOT/replacement/kubectl.log"
 assert_contains "$replacement_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
 assert_contains "$replacement_log" "get nodediagnostic $NODE --ignore-not-found -o jsonpath={.metadata.uid}"
 assert_not_contains "$replacement_log" "delete nodediagnostic"
+
+if run_scenario replacement_during_capture; then
+  fail "capture accepted a replacement NodeDiagnostic"
+fi
+capture_replacement_log="$TEST_ROOT/replacement_during_capture/kubectl.log"
+assert_not_contains "$capture_replacement_log" "get --raw"
+assert_contains "$capture_replacement_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+
+if run_scenario replacement_during_download; then
+  fail "capture accepted a NodeDiagnostic replaced during download"
+fi
+download_replacement_log="$TEST_ROOT/replacement_during_download/kubectl.log"
+assert_contains "$download_replacement_log" "get --raw /api/v1/nodes/$NODE/proxy/logs/support/$NODE-logs.tar.gz"
+if find "$TEST_ROOT/replacement_during_download/output" -type f -name '*-logs.tar.gz' -print -quit | grep -q .; then
+  fail "capture saved a bundle from a replaced NodeDiagnostic"
+fi
 
 echo "eks-node-logs tests passed"

--- a/bin/tests/eks-node-logs-test
+++ b/bin/tests/eks-node-logs-test
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+COMMAND="$ROOT_DIR/bin/eks-node-logs"
+FAKE_KUBECTL="$ROOT_DIR/bin/tests/fake-kubectl"
+NODE="ip-10-0-1-42.us-west-2.compute.internal"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -Fq "$expected" "$file" || fail "expected [$expected] in $file"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq "$unexpected" "$file"; then
+    fail "did not expect [$unexpected] in $file"
+  fi
+}
+
+run_scenario() {
+  local scenario="$1"
+  local run_dir="$TEST_ROOT/$scenario"
+  mkdir -p "$run_dir/bin" "$run_dir/output"
+  ln -s "$FAKE_KUBECTL" "$run_dir/bin/kubectl"
+  FAKE_SCENARIO="$scenario" \
+    FAKE_KUBECTL_LOG="$run_dir/kubectl.log" \
+    PATH="$run_dir/bin:$PATH" \
+    "$COMMAND" --output-dir "$run_dir/output" "$NODE" \
+    >"$run_dir/stdout" 2>"$run_dir/stderr"
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+run_scenario success || fail "successful capture failed"
+success_log="$TEST_ROOT/success/kubectl.log"
+assert_contains "$success_log" "create -f - -o json"
+assert_contains "$success_log" "get --raw /api/v1/nodes/$NODE/proxy/logs/support/$NODE-logs.tar.gz"
+assert_contains "$success_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+bundle=$(find "$TEST_ROOT/success/output" -type f -name '*-logs.tar.gz' -print -quit)
+[[ -n "$bundle" ]] || fail "successful capture did not save a bundle"
+[[ "$(cat "$bundle")" == "diagnostic bundle" ]] || fail "saved bundle content is wrong"
+
+if run_scenario conflict; then
+  fail "create conflict unexpectedly succeeded"
+fi
+assert_not_contains "$TEST_ROOT/conflict/kubectl.log" "delete --raw="
+
+if run_scenario interrupt; then
+  fail "interrupted capture unexpectedly succeeded"
+fi
+assert_contains "$TEST_ROOT/interrupt/kubectl.log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+
+run_scenario replacement || fail "same-name replacement handling failed"
+replacement_log="$TEST_ROOT/replacement/kubectl.log"
+assert_contains "$replacement_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+assert_contains "$replacement_log" "get nodediagnostic $NODE --ignore-not-found -o jsonpath={.metadata.uid}"
+assert_not_contains "$replacement_log" "delete nodediagnostic"
+
+echo "eks-node-logs tests passed"

--- a/bin/tests/eks-node-logs-test
+++ b/bin/tests/eks-node-logs-test
@@ -46,7 +46,7 @@ run_scenario success || fail "successful capture failed"
 success_log="$TEST_ROOT/success/kubectl.log"
 assert_contains "$success_log" "create -f - -o json"
 assert_contains "$success_log" "get --raw /api/v1/nodes/$NODE/proxy/logs/support/$NODE-logs.tar.gz"
-assert_contains "$success_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+assert_contains "$success_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned","resourceVersion":"11"}}'
 bundle=$(find "$TEST_ROOT/success/output" -type f -name '*-logs.tar.gz' -print -quit)
 [[ -n "$bundle" ]] || fail "successful capture did not save a bundle"
 [[ "$(cat "$bundle")" == "diagnostic bundle" ]] || fail "saved bundle content is wrong"
@@ -59,12 +59,12 @@ assert_not_contains "$TEST_ROOT/conflict/kubectl.log" "delete --raw="
 if run_scenario interrupt; then
   fail "interrupted capture unexpectedly succeeded"
 fi
-assert_contains "$TEST_ROOT/interrupt/kubectl.log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+assert_contains "$TEST_ROOT/interrupt/kubectl.log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned","resourceVersion":"11"}}'
 
 run_scenario replacement || fail "same-name replacement handling failed"
 replacement_log="$TEST_ROOT/replacement/kubectl.log"
-assert_contains "$replacement_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
-assert_contains "$replacement_log" "get nodediagnostic $NODE --ignore-not-found -o jsonpath={.metadata.uid}"
+assert_not_contains "$replacement_log" "DELETE_BODY="
+assert_contains "$replacement_log" "get nodediagnostic $NODE --ignore-not-found -o json"
 assert_not_contains "$replacement_log" "delete nodediagnostic"
 
 if run_scenario replacement_during_capture; then
@@ -72,7 +72,7 @@ if run_scenario replacement_during_capture; then
 fi
 capture_replacement_log="$TEST_ROOT/replacement_during_capture/kubectl.log"
 assert_not_contains "$capture_replacement_log" "get --raw"
-assert_contains "$capture_replacement_log" 'DELETE_BODY={"apiVersion":"v1","kind":"DeleteOptions","preconditions":{"uid":"uid-owned"}}'
+assert_not_contains "$capture_replacement_log" "DELETE_BODY="
 
 if run_scenario replacement_during_download; then
   fail "capture accepted a NodeDiagnostic replaced during download"
@@ -82,5 +82,21 @@ assert_contains "$download_replacement_log" "get --raw /api/v1/nodes/$NODE/proxy
 if find "$TEST_ROOT/replacement_during_download/output" -type f -name '*-logs.tar.gz' -print -quit | grep -q .; then
   fail "capture saved a bundle from a replaced NodeDiagnostic"
 fi
+
+if run_scenario updated_during_download; then
+  fail "capture accepted a NodeDiagnostic updated during download"
+fi
+updated_download_log="$TEST_ROOT/updated_during_download/kubectl.log"
+assert_contains "$updated_download_log" "get --raw /api/v1/nodes/$NODE/proxy/logs/support/$NODE-logs.tar.gz"
+assert_not_contains "$updated_download_log" "DELETE_BODY="
+if find "$TEST_ROOT/updated_during_download/output" -type f -name '*-logs.tar.gz' -print -quit | grep -q .; then
+  fail "capture saved a bundle from an updated NodeDiagnostic"
+fi
+
+run_scenario updated_before_cleanup || fail "valid capture failed before cleanup ownership check"
+updated_cleanup_log="$TEST_ROOT/updated_before_cleanup/kubectl.log"
+assert_not_contains "$updated_cleanup_log" "DELETE_BODY="
+bundle=$(find "$TEST_ROOT/updated_before_cleanup/output" -type f -name '*-logs.tar.gz' -print -quit)
+[[ -n "$bundle" ]] || fail "valid bundle was not saved before cleanup update"
 
 echo "eks-node-logs tests passed"

--- a/bin/tests/fake-kubectl
+++ b/bin/tests/fake-kubectl
@@ -18,7 +18,7 @@ if [[ "$1" == "create" ]]; then
     echo "Error from server (AlreadyExists): nodediagnostics.eks.amazonaws.com already exists" >&2
     exit 1
   fi
-  printf '{"metadata":{"uid":"uid-owned"}}\n'
+  printf '{"metadata":{"uid":"uid-owned","generation":1,"resourceVersion":"10"}}\n'
   exit 0
 fi
 
@@ -32,18 +32,31 @@ if [[ "$1" == "wait" ]]; then
 fi
 
 if [[ "$1" == "get" && "$2" == "nodediagnostic" ]]; then
-  if [[ "${5:-}" == "json" ]]; then
+  if [[ "$*" == *"-o json"* ]]; then
     uid="uid-owned"
-    if [[ "$FAKE_SCENARIO" == "replacement_during_capture" ]]; then
+    generation=1
+    resource_version="11"
+    destination="node"
+    reads=$(cat "$FAKE_KUBECTL_STATE" 2>/dev/null || printf '0')
+    printf '%s\n' "$((reads + 1))" >"$FAKE_KUBECTL_STATE"
+
+    if [[ "$FAKE_SCENARIO" == "replacement" && "$reads" -gt 1 ]]; then
       uid="uid-replacement"
-    elif [[ "$FAKE_SCENARIO" == "replacement_during_download" ]]; then
-      reads=$(cat "$FAKE_KUBECTL_STATE" 2>/dev/null || printf '0')
-      printf '%s\n' "$((reads + 1))" >"$FAKE_KUBECTL_STATE"
-      if [[ "$reads" -gt 0 ]]; then
-        uid="uid-replacement"
-      fi
+    elif [[ "$FAKE_SCENARIO" == "replacement_during_capture" ]]; then
+      uid="uid-replacement"
+    elif [[ "$FAKE_SCENARIO" == "replacement_during_download" && "$reads" -gt 0 ]]; then
+      uid="uid-replacement"
+    elif [[ "$FAKE_SCENARIO" == "updated_during_download" && "$reads" -gt 0 ]]; then
+      generation=2
+      resource_version="12"
+      destination="https://example.invalid/upload"
+    elif [[ "$FAKE_SCENARIO" == "updated_before_cleanup" && "$reads" -gt 1 ]]; then
+      generation=2
+      resource_version="12"
+      destination="https://example.invalid/upload"
     fi
-    printf '{"metadata":{"uid":"%s"},"status":{"captureStatuses":[{"state":{"completed":{"reason":"Success","message":"capture complete"}}}]}}\n' "$uid"
+    printf '{"metadata":{"uid":"%s","generation":%s,"resourceVersion":"%s"},"spec":{"logCapture":{"destination":"%s"}},"status":{"captureStatuses":[{"state":{"completed":{"reason":"Success","message":"capture complete"}}}]}}\n' \
+      "$uid" "$generation" "$resource_version" "$destination"
   elif [[ "$*" == *"completed.reason"* ]]; then
     printf 'Success'
   elif [[ "$*" == *"completed.message"* ]]; then

--- a/bin/tests/fake-kubectl
+++ b/bin/tests/fake-kubectl
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FAKE_KUBECTL_LOG"
+
+if [[ "$1" == "get" && "$2" == "crd" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "get" && "$2" == "node" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "create" ]]; then
+  cat >/dev/null
+  if [[ "$FAKE_SCENARIO" == "conflict" ]]; then
+    echo "Error from server (AlreadyExists): nodediagnostics.eks.amazonaws.com already exists" >&2
+    exit 1
+  fi
+  printf '{"metadata":{"uid":"uid-owned"}}\n'
+  exit 0
+fi
+
+if [[ "$1" == "wait" ]]; then
+  if [[ "$FAKE_SCENARIO" == "interrupt" ]]; then
+    kill -TERM "$PPID"
+    sleep 1
+    exit 143
+  fi
+  exit 0
+fi
+
+if [[ "$1" == "get" && "$2" == "nodediagnostic" ]]; then
+  if [[ "$*" == *"completed.reason"* ]]; then
+    printf 'Success'
+  elif [[ "$*" == *"completed.message"* ]]; then
+    printf 'capture complete'
+  elif [[ "$FAKE_SCENARIO" == "replacement" ]]; then
+    printf 'uid-replacement'
+  else
+    printf 'uid-owned'
+  fi
+  exit 0
+fi
+
+if [[ "$1" == "get" && "$2" == "--raw" ]]; then
+  printf 'diagnostic bundle'
+  exit 0
+fi
+
+if [[ "$1" == "delete" && "$2" == --raw=* ]]; then
+  body=$(cat)
+  printf 'DELETE_BODY=%s\n' "$body" >> "$FAKE_KUBECTL_LOG"
+  if [[ "$FAKE_SCENARIO" == "replacement" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "unexpected kubectl invocation: $*" >&2
+exit 2

--- a/bin/tests/fake-kubectl
+++ b/bin/tests/fake-kubectl
@@ -32,11 +32,23 @@ if [[ "$1" == "wait" ]]; then
 fi
 
 if [[ "$1" == "get" && "$2" == "nodediagnostic" ]]; then
-  if [[ "$*" == *"completed.reason"* ]]; then
+  if [[ "${5:-}" == "json" ]]; then
+    uid="uid-owned"
+    if [[ "$FAKE_SCENARIO" == "replacement_during_capture" ]]; then
+      uid="uid-replacement"
+    elif [[ "$FAKE_SCENARIO" == "replacement_during_download" ]]; then
+      reads=$(cat "$FAKE_KUBECTL_STATE" 2>/dev/null || printf '0')
+      printf '%s\n' "$((reads + 1))" >"$FAKE_KUBECTL_STATE"
+      if [[ "$reads" -gt 0 ]]; then
+        uid="uid-replacement"
+      fi
+    fi
+    printf '{"metadata":{"uid":"%s"},"status":{"captureStatuses":[{"state":{"completed":{"reason":"Success","message":"capture complete"}}}]}}\n' "$uid"
+  elif [[ "$*" == *"completed.reason"* ]]; then
     printf 'Success'
   elif [[ "$*" == *"completed.message"* ]]; then
     printf 'capture complete'
-  elif [[ "$FAKE_SCENARIO" == "replacement" ]]; then
+  elif [[ "$FAKE_SCENARIO" == replacement* ]]; then
     printf 'uid-replacement'
   else
     printf 'uid-owned'
@@ -52,7 +64,7 @@ fi
 if [[ "$1" == "delete" && "$2" == --raw=* ]]; then
   body=$(cat)
   printf 'DELETE_BODY=%s\n' "$body" >> "$FAKE_KUBECTL_LOG"
-  if [[ "$FAKE_SCENARIO" == "replacement" ]]; then
+  if [[ "$FAKE_SCENARIO" == replacement* ]]; then
     exit 1
   fi
   exit 0

--- a/docs/eks-node-diagnostics.md
+++ b/docs/eks-node-diagnostics.md
@@ -1,0 +1,106 @@
+# EKS Node Diagnostics
+
+This optional Terraform feature adds AWS's EKS Node Monitoring Agent to the
+CPU-only and CPU-memory node groups. It does not change GroundX Helm workloads,
+repair nodes, or run on GPU nodes. It is disabled by default.
+
+## Enable
+
+Set one value in `terraform/aws/env.tfvars`:
+
+```hcl
+node_diagnostics = {
+  enabled = true
+}
+```
+
+Review the Terraform plan before applying it. The diagnostic change should add
+only `eks-node-monitoring-agent`; it must not replace or resize the cluster or
+node groups. Do not use `bin/environment` for production enablement because it
+applies automatically.
+
+After apply, verify:
+
+```bash
+kubectl -n kube-system get daemonset eks-node-monitoring-agent
+kubectl -n kube-system get pods -l app.kubernetes.io/name=eks-node-monitoring-agent -o wide
+kubectl get nodes -L eyelevel_node
+```
+
+The node-agent pods must run only on nodes labelled
+`eyelevel-cpu-only` or `eyelevel-cpu-memory`. The add-on's NVIDIA monitor is
+disabled and its DCGM component has no eligible nodes, so the existing
+CloudWatch GPU monitoring remains unchanged.
+
+AWS lists node health monitoring as available
+[at no additional cost](https://aws.amazon.com/about-aws/whats-new/2024/12/node-health-monitoring-auto-repair-amazon-eks/).
+The agent still consumes CPU, memory, and temporary bundle disk on each selected
+node; verify its actual footprint in the non-production canary before production.
+
+## Capture one node
+
+Requirements: `kubectl`, `jq`, access to the cluster, permission to create and
+delete `NodeDiagnostic` resources, and permission to use the Kubernetes node
+proxy.
+
+Confirm the current context and exact node, then save the bundle in a protected
+local directory:
+
+```bash
+kubectl config current-context
+kubectl get nodes -L eyelevel_node
+mkdir -m 700 node-evidence
+bin/eks-node-logs --output-dir node-evidence NODE_NAME
+```
+
+The command refuses an existing capture. It creates one temporary
+`NodeDiagnostic`, records its UID, downloads the bundle, and deletes only that
+UID. An interrupted command attempts the same guarded cleanup. A replacement
+with the same name is left untouched.
+
+Bundles contain sensitive host and workload evidence. Do not commit them or
+attach them to tickets without review. For an approved S3 destination, use
+AWS's manual procedure:
+https://docs.aws.amazon.com/eks/latest/userguide/auto-get-logs.html
+
+## Correlate an incident
+
+Record the UTC incident window, node name, instance ID, affected pod or task
+IDs, and the saved bundle path. Collect these read-only surfaces for the same
+window:
+
+```bash
+NODE=NODE_NAME
+INSTANCE_ID=$(kubectl get node "$NODE" -o jsonpath='{.spec.providerID}' | awk -F/ '{print $NF}')
+
+kubectl get node "$NODE" -o yaml
+kubectl get pods -A --field-selector "spec.nodeName=$NODE" -o wide
+kubectl get events -A \
+  --field-selector "involvedObject.kind=Node,involvedObject.name=$NODE" \
+  --sort-by=.metadata.creationTimestamp
+
+aws ec2 describe-instance-status --include-all-instances --instance-ids "$INSTANCE_ID"
+aws autoscaling describe-auto-scaling-instances --instance-ids "$INSTANCE_ID"
+aws ec2 get-console-output --latest --instance-id "$INSTANCE_ID"
+```
+
+In CloudWatch, query the cluster's `host`, `dataplane`, `performance`, and
+`application` Container Insights log groups using the same UTC window, node
+name, and instance ID. Also review the Auto Scaling group's activity history
+for that window. Correlate the first abnormal host signal, the final kubelet
+heartbeat, `NotReady`, pod eviction, task failure, and any replacement or
+scale-up event.
+
+## Unreachable node
+
+Local capture needs enough node and Kubernetes connectivity to complete. If it
+fails, keep the node and instance identifiers and use the Kubernetes,
+CloudWatch, EC2, Auto Scaling, and console evidence above. Do not restart,
+replace, drain, scale, or snapshot anything as part of collection. A root-volume
+snapshot requires separate approval.
+
+## Disable
+
+Set `node_diagnostics.enabled = false` and apply a reviewed Terraform plan.
+This removes the add-on. It does not delete bundles already saved outside
+Terraform.

--- a/docs/eks-node-diagnostics.md
+++ b/docs/eks-node-diagnostics.md
@@ -54,9 +54,10 @@ bin/eks-node-logs --output-dir node-evidence NODE_NAME
 ```
 
 The command refuses an existing capture. It creates one temporary
-`NodeDiagnostic`, records its UID, downloads the bundle, and deletes only that
-UID. An interrupted command attempts the same guarded cleanup. A replacement
-with the same name is left untouched.
+`NodeDiagnostic`, records its UID and generation, downloads the bundle, and
+deletes it only if its identity and capture specification are unchanged. An
+interrupted command attempts the same resource-version-guarded cleanup. A
+replacement or in-place update is left untouched.
 
 Bundles contain sensitive host and workload evidence. Do not commit them or
 attach them to tickets without review. For an approved S3 destination, use

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/README.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/README.md
@@ -1,0 +1,3 @@
+# add-opt-in-eks-node-diagnostics
+
+Add default-off EKS native node diagnostics and an operator capture runbook to the Terraform-managed GroundX cluster.

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/design.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/design.md
@@ -82,12 +82,12 @@ collection.
 Provide one small repo-owned operator command over the native `NodeDiagnostic`
 API for one exact node and local download. This is a safe frontend to the AWS
 collector, not another collector or service. It uses create-only semantics,
-records the created resource UID, waits for and downloads the bundle, and
-deletes with that UID as a precondition. Status and the downloaded output are
-accepted only while that UID still owns the name. A concurrent or pre-existing
-capture fails without being deleted, replaced, or overlapped. If another
-resource later uses the same node name, the command fails, removes any partial
-download, and leaves the replacement untouched.
+records the created resource UID and generation, waits for and downloads the
+bundle, and deletes with the UID and latest resource version as preconditions.
+Status and output are accepted only while the UID, generation, and local-node
+destination remain unchanged. A concurrent, pre-existing, replaced, or edited
+capture fails without being deleted or overlapped. The command removes any
+partial download and leaves the other operator's resource untouched.
 
 The upstream `kubectl ekslogs` command deletes resources by node name, including
 pre-existing resources. Do not invoke or copy that ownership behavior. Keep
@@ -163,8 +163,9 @@ production plan to show no unrelated change.
   not background automation.
 - **Sensitive bundles:** save locally by default and use existing access and
   retention controls for any separately approved manual upload.
-- **Capture ownership:** create conflicts and UID-guarded cleanup are verified
-  with focused command tests and a pre-existing-resource canary.
+- **Capture ownership:** create conflicts and identity, generation, and
+  resource-version-guarded cleanup are verified with focused command tests and
+  a pre-existing-resource canary.
 - **Legacy Terraform remains production authority:** keep the change optional
   and AWS-specific; do not make the Helm contract depend on it.
 

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/design.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/design.md
@@ -83,9 +83,11 @@ Provide one small repo-owned operator command over the native `NodeDiagnostic`
 API for one exact node and local download. This is a safe frontend to the AWS
 collector, not another collector or service. It uses create-only semantics,
 records the created resource UID, waits for and downloads the bundle, and
-deletes with that UID as a precondition. A concurrent or pre-existing capture
-fails without being deleted, replaced, or overlapped. If another resource later
-uses the same node name, cleanup leaves it untouched.
+deletes with that UID as a precondition. Status and the downloaded output are
+accepted only while that UID still owns the name. A concurrent or pre-existing
+capture fails without being deleted, replaced, or overlapped. If another
+resource later uses the same node name, the command fails, removes any partial
+download, and leaves the replacement untouched.
 
 The upstream `kubectl ekslogs` command deletes resources by node name, including
 pre-existing resources. Do not invoke or copy that ownership behavior. Keep

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/design.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/design.md
@@ -1,0 +1,202 @@
+## Context
+
+The production AWS cluster is managed by the bundled `terraform/aws/eks` stack
+even though the repository labels that path legacy. The stack already creates
+managed node groups and installs `amazon-cloudwatch-observability` through its
+`cluster_addons` map.
+
+Recent CPU-node incidents left EC2 running and healthy while Kubernetes lost
+the node. Existing CloudWatch evidence did not establish the final kernel,
+networking, container-runtime, or memory state. AWS now provides these health
+signals and native node log bundles through the EKS Node Monitoring Agent and
+its `NodeDiagnostic` API.
+
+The implementation must be one-switch, inert by default, simple to operate, and
+must not make the cloud-neutral GroundX Helm chart depend on AWS.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One operator choice: `node_diagnostics.enabled`, default `false`.
+- No diagnostic resources or behavioral changes while disabled.
+- AWS-supported node conditions, events, and operator-triggered log bundles.
+- Agent coverage on both configured CPU-only and CPU-memory worker pools.
+- A short incident runbook using existing Kubernetes and AWS evidence paths.
+- Existing Terraform ownership and naming patterns where they are sound.
+
+**Non-Goals:**
+
+- A custom incident collector, automatic capture, or a new evidence service.
+- EKS node repair, node replacement, scaling, restart, cordon, or drain.
+- Terraform-managed alarms, Lambda, EventBridge, SSM documents, lifecycle hooks,
+  snapshots, Flow Logs, or evidence cleanup.
+- Node launch-template, AMI, bootstrap, or journald changes.
+- GroundX Helm, Prometheus, application, Celery, or workload-sizing changes.
+- Applying Terraform or running a failure canary without separate authorization.
+
+## Decisions
+
+### 1. Use one typed, default-off Terraform input
+
+Add the shared input and example value:
+
+```hcl
+node_diagnostics = {
+  enabled = false
+}
+```
+
+When omitted or false, the existing `cluster_addons` map remains unchanged. No
+other diagnostic value is required from the operator.
+
+### 2. Use the AWS-managed Node Monitoring Agent
+
+Conditionally merge `eks-node-monitoring-agent` into the existing
+`cluster_addons` map. Before implementation, identify the production Kubernetes
+version, query the supported add-on versions and configuration schema, and pin
+one exact compatible version that supports the `NodeDiagnostic` `node`
+destination. AWS introduced that destination in `v1.6.1-eksbuild.1`; an older
+version does not support the local-download path.
+
+Configure the add-on's node-agent affinity from `local.cpu_only_label` and
+`local.cpu_memory_label`, so it runs on both configured CPU pools and nowhere
+else. Disable the add-on's NVIDIA monitor and use its supported scheduling
+configuration to leave its DCGM component with no eligible nodes. The existing
+CloudWatch Observability add-on remains the owner of GPU monitoring.
+
+Production discovery on 2026-08-21 confirmed EKS 1.35 and add-on
+`v1.7.0-eksbuild.1`. Its live AWS configuration schema supports `nodeAgent`
+affinity and monitors plus `dcgmAgent.nodeSelector`. The implementation pins
+that version.
+
+Do not enable EKS node repair. The add-on publishes health conditions and events
+only; remediation remains a separate decision.
+
+Alternative considered: deploy a custom watcher or host collector. Rejected
+because the AWS-managed add-on already owns node-health detection and bundle
+collection.
+
+### 3. Use `NodeDiagnostic` for normal evidence capture
+
+Provide one small repo-owned operator command over the native `NodeDiagnostic`
+API for one exact node and local download. This is a safe frontend to the AWS
+collector, not another collector or service. It uses create-only semantics,
+records the created resource UID, waits for and downloads the bundle, and
+deletes with that UID as a precondition. A concurrent or pre-existing capture
+fails without being deleted, replaced, or overlapped. If another resource later
+uses the same node name, cleanup leaves it untouched.
+
+The upstream `kubectl ekslogs` command deletes resources by node name, including
+pre-existing resources. Do not invoke or copy that ownership behavior. Keep
+batch capture and S3 upload logic out of the repo-owned command. The runbook may
+link to AWS's manual S3 procedure for an approved bucket and retention policy;
+this change does not create a bucket or execution role.
+
+The bundle is treated as sensitive operational evidence. It is not committed,
+attached to a ticket, or shared outside the approved incident path without
+review.
+
+Alternative considered: recreate the same collection with a Terraform-packaged
+Lambda and SSM document. Rejected because it duplicates an AWS-supported path
+and adds code, IAM, event delivery, retention, and failure modes.
+
+### 4. Keep existing CloudWatch as supporting evidence
+
+The current CloudWatch Observability add-on already owns Container Insights and
+host, data-plane, and application log shipping. The implementation verifies the
+actual enabled configuration and resulting log groups but does not replace or
+extend that pipeline.
+
+The incident runbook correlates the native bundle with Kubernetes node and pod
+state, recent events, CloudWatch node metrics and logs, EC2 status, Auto Scaling
+activity, and EC2 console output using UTC timestamps, node name, and instance
+ID.
+
+On a reachable node, verify that the native bundle contains the expected
+kernel, memory, storage, container-runtime, and networking sources. If those
+sources are absent, stop and revise the plan. Do not add a custom collector or
+bootstrap change as an unreviewed fallback.
+
+### 5. Make unreachable-node fallback explicit and manual
+
+`NodeDiagnostic` requires enough node connectivity to collect or return the
+bundle. When it cannot, the runbook preserves the incident identity and gathers
+the remaining read-only Kubernetes and AWS evidence plus EC2 console output.
+
+With separate authorization, the non-production canary removes EKS API
+connectivity from a disposable CPU node while preserving CloudWatch and EC2
+connectivity. It verifies that final host and data-plane logs, node conditions
+and events, and EC2 and Auto Scaling timestamps remain available, and that the
+native capture failure is clear. Stop and revise the plan if this evidence still
+cannot explain the motivating node-disconnection event. Do not claim that this
+single canary proves unrelated failure modes.
+
+If offline disk evidence is still required, a root-volume snapshot is a
+separate operator-approved action. This plan does not automatically delay
+termination, create snapshots, or delete evidence. The known incident left the
+instance running, so automatic termination interception is not justified yet.
+
+### 6. Pin the applied EKS module before planning the change
+
+The current `~> 20.0` constraint permits an unrelated module upgrade because
+Terraform does not lock registry module versions in the provider lock file.
+Determine the exact module version used by the production workspace and pin it
+before reviewing the diagnostic diff. Stop if that version cannot be
+established.
+
+The production cluster was created after `20.37.2` became the final `20.x`
+release. The repository wrapper runs `terraform init -upgrade`, and the current
+constraint resolves to `20.37.2`. Pin that version and still require the
+production plan to show no unrelated change.
+
+## Risks / Trade-offs
+
+- **CPU-pool add-on:** the managed agent runs on both configured CPU pools.
+  Verify the pinned version's resources, tolerations, privileges, and absence
+  from GPU pools while leaving existing CloudWatch GPU monitoring unchanged.
+- **Native capture needs node connectivity:** use CloudWatch and EC2 console
+  evidence when the node cannot return a bundle. Prove that path with an
+  isolated disposable node. A snapshot remains an explicit incident operation,
+  not background automation.
+- **Sensitive bundles:** save locally by default and use existing access and
+  retention controls for any separately approved manual upload.
+- **Capture ownership:** create conflicts and UID-guarded cleanup are verified
+  with focused command tests and a pre-existing-resource canary.
+- **Legacy Terraform remains production authority:** keep the change optional
+  and AWS-specific; do not make the Helm contract depend on it.
+
+## Migration Plan
+
+1. Fetch the remote and create the implementation branch from
+   `origin/0.2.7`; record and verify the branch point.
+2. Determine and pin the EKS module version used by production.
+3. Determine the target Kubernetes version, pin a compatible Node Monitoring
+   Agent version with `NodeDiagnostic` `node` destination support, and verify
+   its supported CPU scheduling configuration.
+4. Add the default-off input and conditional managed add-on, targeted to both
+   configured CPU pools without changing existing GPU monitoring. Prove omitted
+   and false plans are unchanged.
+5. Add the exact-node, local-download operator command and runbook for atomic
+   capture ownership and read-only AWS and Kubernetes correlation, with manual
+   AWS S3 guidance and the separately approved snapshot fallback.
+6. Review an enabled non-production plan. It must contain only the module pin,
+   managed add-on, and documented input changes.
+7. With separate authorization, canary the exact add-on and operator command.
+   Verify create-conflict refusal, owned cleanup, node conditions, events,
+   reachable bundle contents, CPU-pool scheduling, absence from GPU pools,
+   resource use, disable behavior, and the focused fallback after removing a
+   disposable CPU node's EKS API connectivity. Stop if the evidence is
+   insufficient for the motivating disconnection.
+8. Submit the verified implementation as a PR whose base branch is `0.2.7`.
+9. Obtain separate production approval, review the production Terraform plan,
+   and enable it without using the auto-approved `bin/environment` wrapper.
+10. Review one natural incident before adding any automatic capture or repair.
+
+Rollback sets `node_diagnostics.enabled` to `false` and applies a reviewed plan.
+This removes the add-on without changing GroundX workloads or deleting bundles
+saved outside Terraform.
+
+## Open Questions
+
+None. Cluster and add-on version discovery are rollout gates, not design choices.

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/proposal.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+Recurring production EKS nodes become unreachable while EC2 health remains
+green, but existing telemetry has not preserved enough final host evidence to
+establish the guest-level cause. The Terraform-managed cluster needs a simple,
+explicitly enabled diagnostic path that improves node evidence without changing
+GroundX application behavior or adding a new incident-processing service.
+
+## What Changes
+
+- Add one Terraform setting, `node_diagnostics.enabled`, defaulting to `false`.
+- Preserve the current Terraform plan when the setting is omitted or `false`:
+  no diagnostic add-on, host configuration, permissions, or Helm changes.
+- When explicitly enabled, install a pinned, cluster-compatible EKS Node
+  Monitoring Agent add-on through the existing `cluster_addons` map. Schedule
+  its node agent only on the configured CPU-only and CPU-memory pools, and do
+  not replace or duplicate the existing CloudWatch GPU monitoring.
+- Use the agent's native node conditions, events, and `NodeDiagnostic` bundles.
+  Provide one small, local-download operator command for one exact failed node.
+  It atomically refuses an existing capture and cleans up only the exact
+  `NodeDiagnostic` identity it created. Keep batch automation and S3 logic out
+  of the command; the runbook may point to AWS's manual S3 procedure.
+- Keep the existing CloudWatch Container Insights logs and metrics as supporting
+  evidence. Do not add another alarm, collector, or log pipeline.
+- Document the fallback when native collection cannot reach the node: preserve
+  the incident identifiers, collect existing Kubernetes, CloudWatch, EC2, and
+  Auto Scaling evidence, retrieve EC2 console output, and request separate
+  approval before taking a root-volume snapshot. Prove the relevant fallback
+  with an authorized canary that removes EKS API connectivity from a disposable
+  non-production CPU node while preserving CloudWatch and EC2 connectivity.
+- Keep automatic capture, Lambda, EventBridge, SSM documents, termination hooks,
+  VPC Flow Logs, scheduled cleanup, batch capture automation, custom S3 upload
+  logic, EKS node repair, application retry behavior, workload sizing, and
+  GroundX Helm workloads outside this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `eks-node-diagnostics`: Terraform-managed, default-off AWS EKS node-health
+  signals plus operator-triggered native diagnostic bundles.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Blast radius:** none while disabled. When enabled, the EKS Node Monitoring
+  Agent runs only on the configured CPU-only and CPU-memory worker pools in the
+  selected cluster. Existing CloudWatch GPU monitoring, GroundX application
+  resources, and Helm values remain unchanged.
+- **Affected environments:** only AWS EKS environments provisioned by the
+  bundled Terraform and explicitly enabled. Non-AWS installs are unaffected.
+- **Stateful impact:** no application-data change and no Terraform-managed
+  diagnostic store. The command saves bundles locally. Manual S3 collection or
+  a root snapshot remains a separate, explicit operation.
+- **Rollout risk:** the enabled add-on consumes small per-node resources and is
+  privileged so it can inspect host state. Canary its exact compatible version
+  and verify its CPU-pool scheduling, absence from GPU pools, isolated-node
+  behavior, and fallback evidence before production.
+- **Rollforward:** create the implementation branch from refreshed
+  `origin/0.2.7`, pin the currently applied EKS Terraform module version, pin a
+  compatible Node Monitoring Agent version, verify the safe operator command
+  and reachable and isolated-node evidence on a disposable cluster node, and
+  submit the PR against `0.2.7`.
+- **Rollback:** set `node_diagnostics.enabled` to `false` and apply a reviewed
+  plan. This removes the add-on and stops new native captures. Previously saved
+  bundles remain under their operator-selected storage and retention policy.
+- **Cost:** the add-on's CPU and memory on the CPU-only and CPU-memory pools,
+  plus any storage an operator explicitly chooses for a bundle or snapshot.
+- **Open design questions:** none. The implementation must discover the target
+  cluster's Kubernetes version, pin a compatible add-on version that supports
+  the `NodeDiagnostic` `node` destination, and verify its supported scheduling
+  configuration; failure to verify compatibility blocks rollout.

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/specs/eks-node-diagnostics/spec.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/specs/eks-node-diagnostics/spec.md
@@ -69,7 +69,8 @@ invocation. It SHALL NOT implement batch or S3 upload behavior.
   target
 - **AND** that resource produces a host log bundle
 - **AND** the bundle is downloaded locally
-- **AND** cleanup deletes only the same resource UID created by that invocation
+- **AND** cleanup deletes only the unchanged resource generation created by
+  that invocation, using UID and resource-version preconditions
 - **AND** no GroundX workload or cluster capacity is modified.
 
 #### Scenario: A selected node already has an active capture
@@ -79,15 +80,18 @@ invocation. It SHALL NOT implement batch or S3 upload behavior.
 - **THEN** capture stops for that target
 - **AND** the existing resource is not deleted, replaced, or overlapped.
 
-#### Scenario: The resource name is reused during capture
+#### Scenario: The capture resource is replaced or edited
 
-- **GIVEN** the command created a `NodeDiagnostic` and recorded its UID
-- **AND** that resource is replaced by another resource with the same node name
+- **GIVEN** the command created a `NodeDiagnostic` and recorded its UID and
+  generation
+- **AND** that resource is replaced under the same name or its specification is
+  edited in place
 - **WHEN** the command reads capture status, downloads the bundle, or performs
   cleanup
-- **THEN** it rejects status or output that cannot be tied to the recorded UID
+- **THEN** it rejects status or output that cannot be tied to the recorded UID,
+  generation, and local-node destination
 - **AND** it removes any partial local bundle
-- **AND** the replacement resource is not deleted.
+- **AND** the replacement or edited resource is not deleted.
 
 ### Requirement: Incident evidence is correlated outside the bundle
 

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/specs/eks-node-diagnostics/spec.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/specs/eks-node-diagnostics/spec.md
@@ -79,12 +79,15 @@ invocation. It SHALL NOT implement batch or S3 upload behavior.
 - **THEN** capture stops for that target
 - **AND** the existing resource is not deleted, replaced, or overlapped.
 
-#### Scenario: The resource name is reused before cleanup
+#### Scenario: The resource name is reused during capture
 
 - **GIVEN** the command created a `NodeDiagnostic` and recorded its UID
 - **AND** that resource is replaced by another resource with the same node name
-- **WHEN** the command performs cleanup
-- **THEN** the replacement resource is not deleted.
+- **WHEN** the command reads capture status, downloads the bundle, or performs
+  cleanup
+- **THEN** it rejects status or output that cannot be tied to the recorded UID
+- **AND** it removes any partial local bundle
+- **AND** the replacement resource is not deleted.
 
 ### Requirement: Incident evidence is correlated outside the bundle
 

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/specs/eks-node-diagnostics/spec.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/specs/eks-node-diagnostics/spec.md
@@ -1,0 +1,184 @@
+## ADDED Requirements
+
+### Requirement: Diagnostics are explicitly enabled
+
+The AWS EKS Terraform SHALL expose `node_diagnostics.enabled` as the only
+required operator input for node diagnostics, and it SHALL default to `false`.
+
+#### Scenario: Setting is omitted
+
+- **GIVEN** `node_diagnostics` is omitted
+- **WHEN** Terraform plans the EKS stack
+- **THEN** the effective value is disabled
+- **AND** no diagnostic add-on, permission, host configuration, or Helm change
+  is planned.
+
+#### Scenario: Setting is false
+
+- **GIVEN** `node_diagnostics.enabled` is `false`
+- **WHEN** Terraform plans the EKS stack
+- **THEN** the diagnostic plan is identical to the omitted-setting plan.
+
+#### Scenario: Setting is true
+
+- **GIVEN** `node_diagnostics.enabled` is `true`
+- **WHEN** Terraform plans the EKS stack
+- **THEN** it conditionally adds one pinned, cluster-compatible EKS Node
+  Monitoring Agent add-on
+- **AND** it requires no other diagnostic value.
+
+### Requirement: Enabled diagnostics use AWS-native node health
+
+Enabled diagnostics SHALL use the EKS Node Monitoring Agent to publish node
+health conditions and events and SHALL NOT enable automatic node repair.
+
+#### Scenario: Add-on is enabled
+
+- **GIVEN** diagnostics are enabled
+- **WHEN** the pinned add-on is deployed
+- **THEN** its node agent runs only on the CPU-only and CPU-memory worker pools
+  selected by their configured labels
+- **AND** the add-on supports the `NodeDiagnostic` `node` destination required
+  for local bundle download
+- **AND** its NVIDIA monitor and DCGM component do not run on GPU nodes
+- **AND** existing CloudWatch GPU monitoring remains unchanged
+- **AND** kernel, networking, container-runtime, storage, and memory findings
+  can appear as node conditions or events
+- **AND** no node is automatically repaired, restarted, or replaced.
+
+#### Scenario: CPU incident is investigated
+
+- **GIVEN** the affected node belongs to the CPU-only or CPU-memory pool
+- **WHEN** an operator begins a CPU-node investigation
+- **THEN** the operator selects the exact failed node by default
+- **AND** the node agent is already scheduled on that pool.
+
+### Requirement: Reachable nodes use native diagnostic bundles
+
+The operator workflow SHALL use one repo-owned, exact-node command over the Node
+Monitoring Agent's native `NodeDiagnostic` API for local host evidence capture.
+It SHALL atomically own and clean up only the resource created by that
+invocation. It SHALL NOT implement batch or S3 upload behavior.
+
+#### Scenario: A node can return a bundle
+
+- **GIVEN** diagnostics are enabled
+- **AND** the affected node can serve a `NodeDiagnostic` request
+- **WHEN** the operator runs the documented capture command
+- **THEN** it creates a temporary `NodeDiagnostic` only if none exists for the
+  target
+- **AND** that resource produces a host log bundle
+- **AND** the bundle is downloaded locally
+- **AND** cleanup deletes only the same resource UID created by that invocation
+- **AND** no GroundX workload or cluster capacity is modified.
+
+#### Scenario: A selected node already has an active capture
+
+- **GIVEN** a selected node has an existing `NodeDiagnostic`
+- **WHEN** the operator attempts the atomic create
+- **THEN** capture stops for that target
+- **AND** the existing resource is not deleted, replaced, or overlapped.
+
+#### Scenario: The resource name is reused before cleanup
+
+- **GIVEN** the command created a `NodeDiagnostic` and recorded its UID
+- **AND** that resource is replaced by another resource with the same node name
+- **WHEN** the command performs cleanup
+- **THEN** the replacement resource is not deleted.
+
+### Requirement: Incident evidence is correlated outside the bundle
+
+The operator workflow SHALL correlate the native bundle with existing
+Kubernetes and AWS evidence using UTC timestamps, node name, and EC2 instance
+ID.
+
+#### Scenario: Operator records an incident
+
+- **WHEN** diagnostic collection begins
+- **THEN** the workflow records node conditions, bound pods, recent events,
+  existing CloudWatch node metrics and logs, EC2 status, Auto Scaling activity,
+  and EC2 console output when available
+- **AND** all normal collection steps are read-only except creation and cleanup
+  of the temporary `NodeDiagnostic`.
+
+### Requirement: Unreachable-node fallback remains explicit
+
+The operator workflow SHALL report native collection failure and SHALL NOT
+automatically mutate infrastructure to preserve evidence.
+
+#### Scenario: Node cannot return a bundle
+
+- **GIVEN** diagnostics are enabled
+- **WHEN** `NodeDiagnostic` cannot complete
+- **THEN** the workflow preserves the node, instance, and incident identifiers
+- **AND** it gathers the remaining existing Kubernetes, CloudWatch, EC2, Auto
+  Scaling, and console evidence
+- **AND** it identifies a root-volume snapshot as a separate action requiring
+  explicit approval when offline disk evidence is needed.
+
+#### Scenario: Unreachable-node fallback is canaried
+
+- **GIVEN** separate authorization and a disposable non-production CPU node
+- **WHEN** EKS API connectivity is removed while CloudWatch and EC2 connectivity
+  remain available until `NodeDiagnostic` cannot complete
+- **THEN** final host and data-plane logs, node conditions and events, EC2 and
+  Auto Scaling timestamps, console evidence, and the native capture failure are
+  collected
+- **AND** rollout stops for plan revision if that evidence cannot explain the
+  motivating node-disconnection event.
+
+#### Scenario: Reachable bundle coverage is checked
+
+- **GIVEN** a disposable non-production CPU node can return a bundle
+- **WHEN** the operator captures and inspects it
+- **THEN** the bundle contains the expected kernel, memory, storage,
+  container-runtime, and networking evidence sources
+- **AND** rollout stops for plan revision if required sources are absent.
+
+### Requirement: Diagnostics do not repair or resize the cluster
+
+This capability SHALL collect evidence only. It SHALL NOT automatically
+restart, reboot, replace, scale, cordon, drain, delete, or delay termination of
+nodes or pods.
+
+#### Scenario: Evidence capture completes or fails
+
+- **WHEN** native capture succeeds or fails
+- **THEN** desired, minimum, and maximum node-group capacity are unchanged
+- **AND** remediation still requires a separate explicit change.
+
+### Requirement: Diagnostic bundles are handled as sensitive evidence
+
+The operator workflow SHALL keep bundle storage and sharing explicit.
+
+#### Scenario: Bundle is downloaded
+
+- **WHEN** an operator receives a diagnostic bundle
+- **THEN** it is stored locally
+- **AND** it is not committed, attached to a ticket, or shared outside the
+  approved incident path without review.
+
+#### Scenario: Manual S3 collection is required
+
+- **WHEN** an operator chooses AWS's manual S3 collection path
+- **THEN** it uses an existing approved bucket and retention policy
+- **AND** this capability does not create or own a diagnostic bucket or upload
+  logic.
+
+#### Scenario: Diagnostics are disabled
+
+- **WHEN** the operator sets `node_diagnostics.enabled` to `false`
+- **THEN** the managed add-on is removed and new native captures stop
+- **AND** previously saved bundles are not deleted by Terraform.
+
+### Requirement: GroundX Helm behavior remains unchanged
+
+The diagnostics capability SHALL remain AWS infrastructure configuration and
+SHALL NOT modify the GroundX application chart or its published mirror.
+
+#### Scenario: Diagnostics are implemented
+
+- **WHEN** the implementation diff is reviewed
+- **THEN** `src/groundx`, `helm`, GroundX workloads, queues, databases, caches,
+  object stores, HPAs, and application images are unchanged
+- **AND** non-AWS deployments are unaffected.

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
@@ -31,13 +31,14 @@
 - [x] 3.1 Add and document one small repo-owned, exact-node operator command over
   the native `NodeDiagnostic` API. Download the bundle locally; do not implement
   batch or S3 upload behavior.
-- [x] 3.2 Use create-only semantics, record the created resource UID, and use
-  that UID as a cleanup precondition. Leave a pre-existing, concurrent, or
-  same-name replacement resource untouched.
+- [x] 3.2 Use create-only semantics, record the created resource UID and
+  generation, and use the UID and latest resource version as cleanup
+  preconditions. Leave a pre-existing, concurrent, replaced, or edited resource
+  untouched.
 - [x] 3.3 Add focused command tests with a stubbed `kubectl` for successful local
-  capture, create conflict, interruption, and same-name replacement during
-  capture, download, or cleanup. Verify status and output belong to the created
-  UID and only that resource can be deleted.
+  capture, create conflict, interruption, same-name replacement, and in-place
+  update during capture, download, or cleanup. Verify status and output belong
+  to the unchanged created generation and only that resource can be deleted.
 - [x] 3.4 Document AWS's manual S3 procedure only as a separate option using an
   existing approved bucket and retention policy.
 - [x] 3.5 Document UTC correlation across the bundle, node name, instance ID,
@@ -60,8 +61,9 @@
 - [ ] 4.3 Review an enabled non-production plan and prove it contains only the
   exact EKS module pin, input, and managed add-on changes.
 - [x] 4.4 Run the focused operator-command tests and prove create conflicts,
-  interruption, and same-name replacement cannot accept another resource's
-  status or output or delete a resource the command did not create.
+  interruption, same-name replacement, and in-place updates cannot accept
+  another capture's status or output or delete a resource the command no longer
+  owns unchanged.
 - [ ] 4.5 With separate authorization, canary the exact add-on version in a
   disposable non-production cluster. Verify node conditions and events, native
   bundle collection, refusal to alter a pre-existing capture, owned cleanup,

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
@@ -84,7 +84,7 @@
 - [x] 5.1 Document the default-off setting, CPU-pool add-on impact, capture
   command, evidence locations, cost, disable procedure, and the fact that the
   feature does not repair nodes.
-- [ ] 5.2 Submit the verified implementation as a PR whose base branch is
+- [x] 5.2 Submit the verified implementation as a PR whose base branch is
   `0.2.7`; verify the PR does not target the repository default branch.
 - [ ] 5.3 Obtain explicit production approval and review the production
   Terraform plan; do not use the auto-approved `bin/environment` wrapper.

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
@@ -22,7 +22,7 @@
 - [x] 2.3 Conditionally merge the pinned add-on into the existing
   `cluster_addons` map without enabling EKS node repair or adding new AWS
   permissions.
-- [ ] 2.4 Record the verified managed-add-on scheduling, tolerations,
+- [x] 2.4 Record the verified managed-add-on scheduling, tolerations,
   privileges, requests, and limits. Verify its pods run on both configured CPU
   pools and not on GPU pools, while existing CloudWatch GPU monitoring remains.
 
@@ -64,15 +64,15 @@
   interruption, same-name replacement, and in-place updates cannot accept
   another capture's status or output or delete a resource the command no longer
   owns unchanged.
-- [ ] 4.5 With separate authorization, canary the exact add-on version in a
+- [x] 4.5 With separate authorization, canary the exact add-on version in a
   disposable non-production cluster. Verify node conditions and events, native
   bundle collection, refusal to alter a pre-existing capture, owned cleanup,
   scheduling on both CPU pools and nowhere else, resource use, unchanged
   CloudWatch GPU monitoring, and disable behavior.
-- [ ] 4.6 Inspect a reachable bundle for the expected kernel, memory, storage,
+- [x] 4.6 Inspect a reachable bundle for the expected kernel, memory, storage,
   container-runtime, and networking evidence sources. Stop and revise the plan
   if required sources are absent.
-- [ ] 4.7 With separate authorization, remove EKS API connectivity from a
+- [x] 4.7 With separate authorization, remove EKS API connectivity from a
   disposable non-production CPU node while preserving CloudWatch and EC2
   connectivity. Confirm final host and data-plane logs, node conditions and
   events, EC2 and Auto Scaling timestamps, console evidence, and a clear native
@@ -81,6 +81,29 @@
 - [x] 4.8 Run existing Helm lint, unit, and minikube render gates and confirm
   `src/groundx`, `helm`, and their rendered manifests are unchanged.
 - [x] 4.9 Run strict OpenSpec validation.
+
+Canary evidence, 2026-08-22: an authorized disposable EKS 1.35 cluster in
+`us-west-1` ran `eks-node-monitoring-agent` `v1.7.0-eksbuild.1` on exactly one
+CPU-only and one CPU-memory node. The node agent requested 10m CPU and 30 MiB,
+limited 250m CPU and 200 MiB, used about 4 to 6m CPU and 49 to 51 MiB, and kept
+its vendor tolerations and documented privileged host access. Its exact CPU-pool
+affinity excluded other pools, NVIDIA monitoring was disabled, the DCGM selector
+matched no node, and the existing CloudWatch add-on remained active. Both
+reachable captures contained kernel, memory-pressure, storage, containerd, and
+networking evidence; one also reported a missing optional VPC CNI IPAM file
+without losing the other sources. A pre-existing capture was preserved, owned
+captures were removed, and the disabled plan removed only this add-on.
+
+At 02:53:28 UTC, the CPU-only node was denied only EKS API TCP/443 while EC2 and
+CloudWatch connectivity remained available. Kubernetes changed it to
+`NodeStatusUnknown` at 02:54:11 and marked an ordinary pod for eviction at
+02:59:11. EC2 reachability and Auto Scaling health stayed healthy. CloudWatch
+continued recording normal node CPU, memory, disk, and network metrics plus
+kubelet connection failures to both EKS endpoint IPs after Kubernetes lost the
+node. Native capture timed out clearly and cleaned up its owned request. The
+EC2 console output remained available. The cluster, nodes, add-ons, IAM,
+networking, logs, and Terraform state were then destroyed; no canary resources
+remain.
 
 ## 5. Production Handoff
 

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
@@ -35,8 +35,9 @@
   that UID as a cleanup precondition. Leave a pre-existing, concurrent, or
   same-name replacement resource untouched.
 - [x] 3.3 Add focused command tests with a stubbed `kubectl` for successful local
-  capture, create conflict, interruption, and same-name replacement before
-  cleanup. Verify only the resource UID created by the command can be deleted.
+  capture, create conflict, interruption, and same-name replacement during
+  capture, download, or cleanup. Verify status and output belong to the created
+  UID and only that resource can be deleted.
 - [x] 3.4 Document AWS's manual S3 procedure only as a separate option using an
   existing approved bucket and retention policy.
 - [x] 3.5 Document UTC correlation across the bundle, node name, instance ID,
@@ -59,8 +60,8 @@
 - [ ] 4.3 Review an enabled non-production plan and prove it contains only the
   exact EKS module pin, input, and managed add-on changes.
 - [x] 4.4 Run the focused operator-command tests and prove create conflicts,
-  interruption, and same-name replacement cannot delete a resource the command
-  did not create.
+  interruption, and same-name replacement cannot accept another resource's
+  status or output or delete a resource the command did not create.
 - [ ] 4.5 With separate authorization, canary the exact add-on version in a
   disposable non-production cluster. Verify node conditions and events, native
   bundle collection, refusal to alter a pre-existing capture, owned cleanup,

--- a/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
+++ b/openspec/changes/add-opt-in-eks-node-diagnostics/tasks.md
@@ -1,0 +1,92 @@
+## 1. Establish Safe Terraform Baseline
+
+- [x] 1.1 Fetch the remote, create the implementation branch from
+  `origin/0.2.7`, and record and verify the branch point before changing files.
+- [x] 1.2 Identify the exact EKS module version used by the production
+  Terraform workspace and pin it; stop if it cannot be established.
+- [x] 1.3 Add the typed `node_diagnostics.enabled` input with default `false`
+  and document the single-value enablement in `env.tfvars.example`.
+- [x] 1.4 Prove omitted and explicit-false inputs leave the existing
+  `cluster_addons` map and Terraform plan unchanged.
+
+## 2. Add The Managed Node Monitoring Agent
+
+- [x] 2.1 Identify the target Kubernetes version, query supported
+  `eks-node-monitoring-agent` versions and configuration, and pin one exact
+  version that supports the `NodeDiagnostic` `node` destination introduced in
+  `v1.6.1-eksbuild.1`.
+- [x] 2.2 Configure node-agent affinity from `local.cpu_only_label` and
+  `local.cpu_memory_label`. Disable the add-on's NVIDIA monitor and use supported
+  scheduling configuration so its DCGM component has no eligible nodes, without
+  changing the existing CloudWatch GPU monitoring.
+- [x] 2.3 Conditionally merge the pinned add-on into the existing
+  `cluster_addons` map without enabling EKS node repair or adding new AWS
+  permissions.
+- [ ] 2.4 Record the verified managed-add-on scheduling, tolerations,
+  privileges, requests, and limits. Verify its pods run on both configured CPU
+  pools and not on GPU pools, while existing CloudWatch GPU monitoring remains.
+
+## 3. Document The Operator Capture Path
+
+- [x] 3.1 Add and document one small repo-owned, exact-node operator command over
+  the native `NodeDiagnostic` API. Download the bundle locally; do not implement
+  batch or S3 upload behavior.
+- [x] 3.2 Use create-only semantics, record the created resource UID, and use
+  that UID as a cleanup precondition. Leave a pre-existing, concurrent, or
+  same-name replacement resource untouched.
+- [x] 3.3 Add focused command tests with a stubbed `kubectl` for successful local
+  capture, create conflict, interruption, and same-name replacement before
+  cleanup. Verify only the resource UID created by the command can be deleted.
+- [x] 3.4 Document AWS's manual S3 procedure only as a separate option using an
+  existing approved bucket and retention policy.
+- [x] 3.5 Document UTC correlation across the bundle, node name, instance ID,
+  Kubernetes node and pod state, recent events, existing CloudWatch logs and
+  metrics, EC2 status, Auto Scaling activity, and EC2 console output.
+- [x] 3.6 Document failed native collection plainly. Keep any root-volume
+  snapshot as a separate, explicitly approved incident action; do not automate
+  alarms, capture, termination delay, snapshot creation, or deletion.
+- [x] 3.7 Document that bundles are sensitive operational evidence and must not
+  be committed or attached to tickets without review.
+
+## 4. Validate The Smallest Implementation
+
+- [x] 4.1 Initialize and validate the EKS stack without modifying remote state,
+  format-check the new Terraform test, run shell syntax and safety tests, and
+  run `git diff --check`. Do not reformat the nine pre-existing Terraform files
+  that fail the recursive formatting check on `0.2.7`.
+- [ ] 4.2 Review an omitted and disabled plan against current state and prove
+  there is no diagnostic or Helm change.
+- [ ] 4.3 Review an enabled non-production plan and prove it contains only the
+  exact EKS module pin, input, and managed add-on changes.
+- [x] 4.4 Run the focused operator-command tests and prove create conflicts,
+  interruption, and same-name replacement cannot delete a resource the command
+  did not create.
+- [ ] 4.5 With separate authorization, canary the exact add-on version in a
+  disposable non-production cluster. Verify node conditions and events, native
+  bundle collection, refusal to alter a pre-existing capture, owned cleanup,
+  scheduling on both CPU pools and nowhere else, resource use, unchanged
+  CloudWatch GPU monitoring, and disable behavior.
+- [ ] 4.6 Inspect a reachable bundle for the expected kernel, memory, storage,
+  container-runtime, and networking evidence sources. Stop and revise the plan
+  if required sources are absent.
+- [ ] 4.7 With separate authorization, remove EKS API connectivity from a
+  disposable non-production CPU node while preserving CloudWatch and EC2
+  connectivity. Confirm final host and data-plane logs, node conditions and
+  events, EC2 and Auto Scaling timestamps, console evidence, and a clear native
+  capture failure remain available. Stop and revise the plan if that evidence
+  cannot explain the motivating node-disconnection event.
+- [x] 4.8 Run existing Helm lint, unit, and minikube render gates and confirm
+  `src/groundx`, `helm`, and their rendered manifests are unchanged.
+- [x] 4.9 Run strict OpenSpec validation.
+
+## 5. Production Handoff
+
+- [x] 5.1 Document the default-off setting, CPU-pool add-on impact, capture
+  command, evidence locations, cost, disable procedure, and the fact that the
+  feature does not repair nodes.
+- [ ] 5.2 Submit the verified implementation as a PR whose base branch is
+  `0.2.7`; verify the PR does not target the repository default branch.
+- [ ] 5.3 Obtain explicit production approval and review the production
+  Terraform plan; do not use the auto-approved `bin/environment` wrapper.
+- [ ] 5.4 Review one natural incident before proposing automatic capture,
+  termination hooks, snapshots, or node repair.

--- a/terraform/aws/eks/eks.tf
+++ b/terraform/aws/eks/eks.tf
@@ -11,6 +11,7 @@ locals {
     var.node_diagnostics.enabled ? {
       eks-node-monitoring-agent = {
         addon_version = "v1.7.0-eksbuild.1"
+        preserve      = false
         configuration_values = jsonencode({
           nodeAgent = {
             affinity = {

--- a/terraform/aws/eks/eks.tf
+++ b/terraform/aws/eks/eks.tf
@@ -1,6 +1,49 @@
 locals {
   should_create = var.environment.vpc_id != "" && length(var.environment.subnets) > 0
 
+  cluster_addons = merge(
+    {
+      amazon-cloudwatch-observability = {
+        resolve_conflicts_on_create = "OVERWRITE"
+        resolve_conflicts_on_update = "OVERWRITE"
+      }
+    },
+    var.node_diagnostics.enabled ? {
+      eks-node-monitoring-agent = {
+        addon_version = "v1.7.0-eksbuild.1"
+        configuration_values = jsonencode({
+          nodeAgent = {
+            affinity = {
+              nodeAffinity = {
+                requiredDuringSchedulingIgnoredDuringExecution = {
+                  nodeSelectorTerms = [{
+                    matchExpressions = [{
+                      key      = "eyelevel_node"
+                      operator = "In"
+                      values   = [local.cpu_only_label, local.cpu_memory_label]
+                    }]
+                  }]
+                }
+              }
+            }
+            monitors = {
+              nvidia = {
+                enabled = false
+              }
+            }
+          }
+          dcgmAgent = {
+            nodeSelector = {
+              "diagnostics.groundx.ai/dcgm" = "disabled"
+            }
+          }
+        })
+        resolve_conflicts_on_create = "OVERWRITE"
+        resolve_conflicts_on_update = "OVERWRITE"
+      }
+    } : {}
+  )
+
   access_entries = merge({
     for entry in var.environment.cluster_role_arns : entry.name => {
       kubernetes_groups = []
@@ -322,7 +365,7 @@ module "eyelevel_eks" {
   count = local.should_create ? 1 : 0
 
   source                                   = "terraform-aws-modules/eks/aws"
-  version                                  = "~> 20.0"
+  version                                  = "20.37.2"
 
   enable_irsa                              = true
 
@@ -346,12 +389,7 @@ module "eyelevel_eks" {
 
   eks_managed_node_groups                  = local.node_groups
 
-  cluster_addons = {
-    amazon-cloudwatch-observability = {
-      resolve_conflicts_on_create = "OVERWRITE"
-      resolve_conflicts_on_update = "OVERWRITE"
-    }
-  }
+  cluster_addons                           = local.cluster_addons
 }
 
 resource "null_resource" "wait_for_eks" {

--- a/terraform/aws/eks/tests/node_diagnostics.tftest.hcl
+++ b/terraform/aws/eks/tests/node_diagnostics.tftest.hcl
@@ -1,0 +1,117 @@
+mock_provider "aws" {}
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+mock_provider "null" {}
+mock_provider "random" {}
+
+variables {
+  environment = {
+    cluster_role_arns = []
+    region            = "us-west-2"
+    security_groups   = []
+    ssh_key_name      = "test"
+    stage             = "test"
+    subnets           = ["subnet-test"]
+    vpc_id            = "vpc-test"
+  }
+}
+
+override_data {
+  target = data.aws_iam_policy_document.app_irsa_trust
+  values = {
+    json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+  }
+}
+
+override_data {
+  target = data.aws_iam_policy_document.s3_sqs_admin
+  values = {
+    json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+  }
+}
+
+override_module {
+  target = module.eyelevel_eks
+  outputs = {
+    cluster_endpoint  = "https://example.invalid"
+    oidc_provider     = "oidc.eks.us-west-2.amazonaws.com/id/test"
+    oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/test"
+  }
+}
+
+override_module {
+  target = module.irsa_autoscaler
+  outputs = {
+    iam_role_arn = "arn:aws:iam::123456789012:role/test-autoscaler"
+  }
+}
+
+override_module {
+  target = module.irsa_efs_csi
+  outputs = {
+    iam_role_arn = "arn:aws:iam::123456789012:role/test-efs-csi"
+  }
+}
+
+run "diagnostics_are_disabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = var.node_diagnostics.enabled == false
+    error_message = "Node diagnostics must default to disabled."
+  }
+
+  assert {
+    condition     = !contains(keys(local.cluster_addons), "eks-node-monitoring-agent")
+    error_message = "The node monitoring add-on must be absent by default."
+  }
+}
+
+run "diagnostics_are_disabled_explicitly" {
+  command = plan
+
+  variables {
+    node_diagnostics = {
+      enabled = false
+    }
+  }
+
+  assert {
+    condition     = !contains(keys(local.cluster_addons), "eks-node-monitoring-agent")
+    error_message = "The node monitoring add-on must be absent when disabled."
+  }
+}
+
+run "diagnostics_cover_only_cpu_pools" {
+  command = plan
+
+  variables {
+    node_diagnostics = {
+      enabled = true
+    }
+  }
+
+  assert {
+    condition     = local.cluster_addons["eks-node-monitoring-agent"].addon_version == "v1.7.0-eksbuild.1"
+    error_message = "The node monitoring add-on version must be pinned."
+  }
+
+  assert {
+    condition = jsondecode(local.cluster_addons["eks-node-monitoring-agent"].configuration_values).nodeAgent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0] == {
+      key      = "eyelevel_node"
+      operator = "In"
+      values   = [local.cpu_only_label, local.cpu_memory_label]
+    }
+    error_message = "The node agent must target both configured CPU pools."
+  }
+
+  assert {
+    condition     = jsondecode(local.cluster_addons["eks-node-monitoring-agent"].configuration_values).nodeAgent.monitors.nvidia.enabled == false
+    error_message = "The node monitoring add-on NVIDIA monitor must be disabled."
+  }
+
+  assert {
+    condition     = jsondecode(local.cluster_addons["eks-node-monitoring-agent"].configuration_values).dcgmAgent.nodeSelector["diagnostics.groundx.ai/dcgm"] == "disabled"
+    error_message = "The add-on DCGM component must have no eligible nodes."
+  }
+}

--- a/terraform/aws/eks/tests/node_diagnostics.tftest.hcl
+++ b/terraform/aws/eks/tests/node_diagnostics.tftest.hcl
@@ -97,6 +97,11 @@ run "diagnostics_cover_only_cpu_pools" {
   }
 
   assert {
+    condition     = local.cluster_addons["eks-node-monitoring-agent"].preserve == false
+    error_message = "Disabling diagnostics must delete the managed add-on."
+  }
+
+  assert {
     condition = jsondecode(local.cluster_addons["eks-node-monitoring-agent"].configuration_values).nodeAgent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0] == {
       key      = "eyelevel_node"
       operator = "In"

--- a/terraform/aws/env.tfvars.example
+++ b/terraform/aws/env.tfvars.example
@@ -11,3 +11,7 @@ environment         = {
 storage = {
   driver = "efs"
 }
+
+node_diagnostics = {
+  enabled = false
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -26,6 +26,14 @@ variable "environment_internal" {
   }
 }
 
+variable "node_diagnostics" {
+  description = "Optional EKS node diagnostics. Disabled unless explicitly enabled."
+  type = object({
+    enabled = optional(bool, false)
+  })
+  default = {}
+}
+
 variable "autoscaler_internal" {
   type           = object({
     chart        = object({


### PR DESCRIPTION
## Summary

- add one default-off `node_diagnostics.enabled` Terraform setting
- pin the existing EKS module and the EKS 1.35-compatible Node Monitoring Agent
- schedule diagnostics only on CPU-only and CPU-memory pools, with NVIDIA and DCGM monitoring excluded
- add an exact-node local capture command with UID and generation ownership checks plus resource-version-guarded cleanup
- leave concurrent replacements and in-place capture updates untouched
- add the operator runbook and OpenSpec change
- leave GroundX Helm workloads and automatic node repair unchanged

## Validation

- `terraform validate`
- `terraform test -filter=tests/node_diagnostics.tftest.hcl`, 3 passed
- final add-on JSON validated against the live AWS `v1.7.0-eksbuild.1` schema
- `bin/tests/eks-node-logs-test`, including replacement and in-place update races
- shell syntax and diff checks
- `.build/bin/validate-helm.sh --junit`, 202 tests and 815 snapshots passed
- minikube Helm render passed
- strict OpenSpec validation passed
- confirmed no `src/groundx` or `helm` changes

## Rollout

This branch starts at `origin/0.2.7`, and the PR targets `0.2.7`.

No Terraform plan, apply, deployment, or cluster mutation was performed. The enabled non-production plan and canary, production plan, and production enablement require separate approval.
