### PR TITLE
fix: preserve external EKS KMS policy

### DIFF
--- a/openspec/changes/preserve-eks-inspector-kms-policy/.openspec.yaml
+++ b/openspec/changes/preserve-eks-inspector-kms-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/preserve-eks-inspector-kms-policy/design.md
+++ b/openspec/changes/preserve-eks-inspector-kms-policy/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The production EKS KMS key contains an Inspector SBOM export statement added
+outside the legacy Terraform. Even a targeted node-monitoring add-on plan walks
+the EKS module dependency graph and proposes removing that statement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Represent existing external KMS statements without changing them.
+- Keep omitted behavior unchanged for every environment.
+- Produce a targeted production plan containing only the diagnostic add-on.
+
+**Non-Goals:**
+
+- Apply Terraform or change the live KMS key.
+- Resolve the unrelated CloudWatch add-on version drift.
+- Move production EKS ownership before the active infrastructure adoption is
+  ready.
+
+## Decisions
+
+Add a default-empty `eks_kms_source_policy_documents` list and pass it directly
+to the pinned EKS module's `kms_key_source_policy_documents` input. This follows
+the module's native policy-merge contract and avoids hard-coding Inspector into
+all installations.
+
+Keep the exact Inspector JSON only in the ignored production `env.tfvars`.
+Other environments receive no new statement or required setting.
+
+Do not use lifecycle ignores, temporary override files, or manual AWS changes.
+Those approaches would hide drift, make the reviewed plan non-reproducible, or
+leave Terraform unable to preserve the live policy on the next run.
+
+## Risks / Trade-offs
+
+- Incorrect policy JSON could rewrite the KMS policy. Mitigation: copy the live
+  statement exactly and require a plan with no KMS action.
+- The input extends deprecated Terraform. Mitigation: keep it as a direct,
+  default-empty pass-through and move ownership to `groundx-production-infra`
+  through its existing adoption plan.
+- The full plan still proposes a CloudWatch add-on upgrade. Mitigation: review
+  only the exact targeted diagnostic plan and do not apply the full plan.
+
+## Migration Plan
+
+1. Add a failing Terraform test for the default and configured pass-through.
+2. Add the input and pass it to the existing EKS module.
+3. Put the exact live Inspector statement in production `env.tfvars`.
+4. Require the targeted production plan to show one add and no other action.
+5. Submit the code against `0.2.7`. Do not apply.
+
+Rollback removes the code input only after production EKS ownership moves or
+the external statement is otherwise represented. Removing it from the active
+legacy configuration earlier would again plan KMS policy removal.
+
+## Open Questions
+
+None.

--- a/openspec/changes/preserve-eks-inspector-kms-policy/proposal.md
+++ b/openspec/changes/preserve-eks-inspector-kms-policy/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Enabling EKS node diagnostics cannot produce an isolated production plan because
+the legacy Terraform does not model an existing Inspector statement on the
+cluster KMS key. The targeted plan would remove that permission.
+
+## What Changes
+
+- Add one optional list of KMS source policy documents, defaulting to empty.
+- Pass configured documents unchanged to the pinned EKS module.
+- Preserve the existing production Inspector SBOM export statement through the
+  ignored production `env.tfvars`.
+- Require the targeted production plan to create only the node monitoring
+  add-on before any separately approved apply.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `eks-node-diagnostics`: A diagnostic rollout must preserve explicitly
+  configured cluster KMS policy statements.
+
+## Impact
+
+- Blast radius: none by default. No cluster redeploys and no AWS resource changes
+  occur until an operator applies a reviewed plan.
+- Affected environments: only AWS EKS environments that explicitly provide KMS
+  source policy documents. The production value describes permission already
+  present in AWS.
+- Stateful impact: none. The change does not modify data, Helm, workloads, node
+  groups, or the existing live KMS policy.
+- Rollforward: merge the default-empty input, set the production-only value, and
+  require a one-create, zero-update, zero-delete targeted plan.
+- Rollback: omit the new input. Do not apply that rollback where external KMS
+  statements must remain.
+- Open design questions: none.

--- a/openspec/changes/preserve-eks-inspector-kms-policy/specs/eks-node-diagnostics/spec.md
+++ b/openspec/changes/preserve-eks-inspector-kms-policy/specs/eks-node-diagnostics/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Diagnostic rollout preserves external KMS policy
+
+The AWS EKS Terraform SHALL pass explicitly configured KMS source policy
+documents unchanged to the EKS module, and SHALL default to no additional
+documents.
+
+#### Scenario: No external policy is configured
+
+- **GIVEN** the KMS source policy input is omitted
+- **WHEN** Terraform plans the EKS stack
+- **THEN** it passes an empty source-policy list to the EKS module
+- **AND** existing environments retain their prior default behavior.
+
+#### Scenario: Production policy is configured
+
+- **GIVEN** the current production Inspector statement is configured as a KMS
+  source policy document
+- **WHEN** Terraform plans the targeted node monitoring add-on
+- **THEN** the statement remains in the planned KMS policy
+- **AND** the plan creates only the node monitoring add-on
+- **AND** it contains no update, replacement, or deletion.

--- a/openspec/changes/preserve-eks-inspector-kms-policy/tasks.md
+++ b/openspec/changes/preserve-eks-inspector-kms-policy/tasks.md
@@ -1,0 +1,28 @@
+## 1. Define The Safety Contract
+
+- [x] 1.1 Verify the targeted production plan includes the existing KMS policy
+  removal through the EKS module dependency graph.
+- [x] 1.2 Record the default-empty pass-through design and zero-change KMS gate.
+
+## 2. Implement With TDD
+
+- [x] 2.1 Add a failing Terraform test proving omitted input is empty and a
+  configured source policy document reaches the EKS module unchanged.
+- [x] 2.2 Add the minimal typed input and EKS module pass-through.
+- [x] 2.3 Add the exact existing Inspector statement to ignored production
+  `env.tfvars` without changing Helm values.
+
+## 3. Validate And Submit
+
+- [x] 3.1 Run the focused Terraform test, `terraform validate`, formatting,
+  strict OpenSpec validation, and `git diff --check`.
+- [x] 3.2 Review a targeted production plan and prove it contains exactly one
+  add-on creation, with no KMS, CloudWatch, Helm, update, replacement, or
+  deletion action.
+- [ ] 3.3 Submit the change against `0.2.7`. Do not apply Terraform.
+
+Production plan evidence, 2026-08-22: the targeted plan against account
+`903713046261`, region `us-west-2`, and cluster `eyelevel_890ng3` contained one
+creation, `eks-node-monitoring-agent` `v1.7.0-eksbuild.1`, and 61 no-op
+resources. It contained no update, replacement, or deletion. The plan was not
+applied.

--- a/openspec/changes/preserve-eks-inspector-kms-policy/tasks.md
+++ b/openspec/changes/preserve-eks-inspector-kms-policy/tasks.md
@@ -19,7 +19,7 @@
 - [x] 3.2 Review a targeted production plan and prove it contains exactly one
   add-on creation, with no KMS, CloudWatch, Helm, update, replacement, or
   deletion action.
-- [ ] 3.3 Submit the change against `0.2.7`. Do not apply Terraform.
+- [x] 3.3 Submit the change against `0.2.7`. Do not apply Terraform.
 
 Production plan evidence, 2026-08-22: the targeted plan against account
 `903713046261`, region `us-west-2`, and cluster `eyelevel_890ng3` contained one

--- a/terraform/aws/eks/eks.tf
+++ b/terraform/aws/eks/eks.tf
@@ -1,5 +1,6 @@
 locals {
-  should_create = var.environment.vpc_id != "" && length(var.environment.subnets) > 0
+  should_create                   = var.environment.vpc_id != "" && length(var.environment.subnets) > 0
+  eks_kms_source_policy_documents = var.eks_kms_source_policy_documents
 
   cluster_addons = merge(
     {
@@ -391,6 +392,7 @@ module "eyelevel_eks" {
   eks_managed_node_groups                  = local.node_groups
 
   cluster_addons                           = local.cluster_addons
+  kms_key_source_policy_documents          = local.eks_kms_source_policy_documents
 }
 
 resource "null_resource" "wait_for_eks" {

--- a/terraform/aws/eks/tests/node_diagnostics.tftest.hcl
+++ b/terraform/aws/eks/tests/node_diagnostics.tftest.hcl
@@ -120,3 +120,27 @@ run "diagnostics_cover_only_cpu_pools" {
     error_message = "The add-on DCGM component must have no eligible nodes."
   }
 }
+
+run "kms_source_policy_documents_default_empty" {
+  command = plan
+
+  assert {
+    condition     = length(local.eks_kms_source_policy_documents) == 0
+    error_message = "Additional EKS KMS source policy documents must default to empty."
+  }
+}
+
+run "kms_source_policy_documents_pass_through" {
+  command = plan
+
+  variables {
+    eks_kms_source_policy_documents = [
+      "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"KeepExistingPolicy\"}]}"
+    ]
+  }
+
+  assert {
+    condition     = local.eks_kms_source_policy_documents == var.eks_kms_source_policy_documents
+    error_message = "Configured EKS KMS source policy documents must pass through unchanged."
+  }
+}

--- a/terraform/aws/env.tfvars.example
+++ b/terraform/aws/env.tfvars.example
@@ -15,3 +15,5 @@ storage = {
 node_diagnostics = {
   enabled = false
 }
+
+eks_kms_source_policy_documents = []

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -34,6 +34,12 @@ variable "node_diagnostics" {
   default = {}
 }
 
+variable "eks_kms_source_policy_documents" {
+  description = "Optional existing policy documents to merge into the EKS cluster KMS key policy."
+  type        = list(string)
+  default     = []
+}
+
 variable "autoscaler_internal" {
   type           = object({
     chart        = object({


### PR DESCRIPTION
## Why

A targeted production plan for the EKS node monitoring add-on also proposed removing the existing Inspector SBOM export statement from the cluster KMS key. The legacy Terraform had no input for external source policy documents.

## Changes

- add a default-empty EKS KMS source policy document input
- pass configured documents to the pinned EKS module
- test omitted and configured behavior
- record the production plan gate in OpenSpec

## Verification

- Terraform test: 5 passed
- Terraform validate: passed
- OpenSpec strict validation: passed
- Helm lint and minikube render: passed
- Helm unit tests: 202 tests and 815 snapshots passed
- targeted production plan: 1 add, 0 changes, 0 deletes

The production plan was not applied. The ignored production `env.tfvars` contains the exact existing Inspector statement and is not part of this PR.