### PR TITLE
Configure extraction capture account allowlists

### DIFF
--- a/helm/templates/resources/config-yaml.yaml
+++ b/helm/templates/resources/config-yaml.yaml
@@ -68,6 +68,8 @@
 {{- $wrpt := include "groundx.workspace.provision.throughput" . | trim -}}
 {{- $wrpubt := include "groundx.workspace.publish.throughput" . | trim -}}
 {{- $wrwt := include "groundx.workspace.workspace.throughput" . | trim -}}
+{{- $integration := .Values.integration | default dict -}}
+{{- $captureAccounts := get $integration "extractionCaptureAccounts" | default list -}}
 {{- if gt (len $svcs) 0 }}
 apiVersion: v1
 kind: ConfigMap
@@ -230,6 +232,10 @@ data:
         username: {{ include "groundx.search.privilegedUsername" . | quote }}
 
     integrationTests:
+{{- if gt (len $captureAccounts) 0 }}
+      extractionCaptureAccounts:
+{{ toYaml $captureAccounts | nindent 8 }}
+{{- end }}
       search:
         duration: {{ include "groundx.integration.search.duration" . }}
         fileId: {{ include "groundx.integration.search.fileId" . | quote }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1868,6 +1868,11 @@
     "integration": {
       "type": "object",
       "properties": {
+        "extractionCaptureAccounts": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
         "search": {
           "type": "object",
           "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -500,6 +500,9 @@ extract:
         cpu: 200m
         memory: 512Mi
 
+integration:
+  extractionCaptureAccounts: []
+
 throughput:
   tpm:
     document: 12500

--- a/openspec/changes/configure-extraction-capture-accounts/design.md
+++ b/openspec/changes/configure-extraction-capture-accounts/design.md
@@ -1,0 +1,17 @@
+# Design
+
+Add `integration.extractionCaptureAccounts` to `values.yaml` and the strict
+values schema. Render the list directly under
+`integrationTests.extractionCaptureAccounts` in the shared GroundX
+`config.yaml`. Omit the runtime key when the default list is empty so current
+rendered configuration and authorization remain unchanged.
+
+Implement in `src/groundx` first, then copy the same values, schema, and
+template changes to the published `helm` mirror. A focused Helm unit test proves
+the default and configured render. Schema checks prove invalid values fail.
+
+The shared ConfigMap hash can roll enabled Go services and metrics. Deploy one
+production Helm revision with the approved internal testing account, wait for
+rollout completion, verify the exact rendered list, and confirm no unrelated
+manifest drift. Roll back by removing the value and upgrading the prior chart
+configuration. No stateful resource changes or migrations occur.

--- a/openspec/changes/configure-extraction-capture-accounts/proposal.md
+++ b/openspec/changes/configure-extraction-capture-accounts/proposal.md
@@ -1,0 +1,22 @@
+# Configure extraction capture accounts
+
+Cashbot already rejects `_groundx_internal_capture` unless the caller account is
+in `integrationTests.extractionCaptureAccounts`. The Helm chart cannot render
+that setting, so governed extraction certification is denied in every Helm
+deployment.
+
+Add an optional `integration.extractionCaptureAccounts` values list and render
+it into `config.yaml`. The default remains empty, so no account gains capture
+access unless an operator explicitly configures it.
+
+The deployment contract, generated GroundX ConfigMap, and workloads whose
+config hash includes that ConfigMap are affected. A rollout may restart enabled
+Go services and the metrics service. Databases, queues, files, customer data,
+workflow compilation, and extraction behavior are unchanged.
+
+Production rollout sets the approved internal testing account, waits for all
+affected workloads to become ready with zero new restarts, and verifies the
+rendered allowlist before certification. Rollback removes the value and repeats
+the Helm upgrade. No data migration is required.
+
+Open design questions: none.

--- a/openspec/changes/configure-extraction-capture-accounts/specs/deployment-config/spec.md
+++ b/openspec/changes/configure-extraction-capture-accounts/specs/deployment-config/spec.md
@@ -1,0 +1,32 @@
+# Extraction capture account configuration
+
+## Requirement: Capture accounts are explicitly configured
+
+The chart SHALL expose `integration.extractionCaptureAccounts` as an array of
+unique, non-empty strings. Its default SHALL be empty.
+
+### Scenario: No accounts are configured
+
+- **GIVEN** the chart's default values
+- **WHEN** the GroundX ConfigMap is rendered
+- **THEN** `integrationTests.extractionCaptureAccounts` is omitted
+- **AND** Cashbot's effective allowlist remains empty
+
+### Scenario: Approved accounts are configured
+
+- **GIVEN** one or more account IDs in `integration.extractionCaptureAccounts`
+- **WHEN** the GroundX ConfigMap is rendered
+- **THEN** `integrationTests.extractionCaptureAccounts` contains those exact IDs
+- **AND** no other account is added
+
+### Scenario: The value has an invalid shape
+
+- **GIVEN** a non-array value, a non-string member, an empty member, or duplicate members
+- **WHEN** Helm validates the values schema
+- **THEN** validation fails before deployment
+
+## Requirement: Capture authorization remains fail closed
+
+This chart setting SHALL only supply Cashbot's existing server-side allowlist.
+It SHALL NOT enable capture by itself or alter workflow capture validation,
+expiry, limits, workflow binding, bucket binding, or extraction behavior.

--- a/openspec/changes/configure-extraction-capture-accounts/tasks.md
+++ b/openspec/changes/configure-extraction-capture-accounts/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Add failing Helm tests for default, configured, and invalid allowlist values.
+- [x] Add the source values, schema, and ConfigMap rendering.
+- [x] Sync the same files into the published Helm mirror.
+- [x] Regenerate snapshots and run `.build/bin/validate-helm.sh`.
+- [ ] Review the rendered production diff, deploy the approved account, and verify rollout health.
+- [ ] Run protected extraction certification, remove temporary resources, and archive this change.

--- a/src/groundx/templates/resources/config-yaml.yaml
+++ b/src/groundx/templates/resources/config-yaml.yaml
@@ -68,6 +68,8 @@
 {{- $wrpt := include "groundx.workspace.provision.throughput" . | trim -}}
 {{- $wrpubt := include "groundx.workspace.publish.throughput" . | trim -}}
 {{- $wrwt := include "groundx.workspace.workspace.throughput" . | trim -}}
+{{- $integration := .Values.integration | default dict -}}
+{{- $captureAccounts := get $integration "extractionCaptureAccounts" | default list -}}
 {{- if gt (len $svcs) 0 }}
 apiVersion: v1
 kind: ConfigMap
@@ -230,6 +232,10 @@ data:
         username: {{ include "groundx.search.privilegedUsername" . | quote }}
 
     integrationTests:
+{{- if gt (len $captureAccounts) 0 }}
+      extractionCaptureAccounts:
+{{ toYaml $captureAccounts | nindent 8 }}
+{{- end }}
       search:
         duration: {{ include "groundx.integration.search.duration" . }}
         fileId: {{ include "groundx.integration.search.fileId" . | quote }}

--- a/src/groundx/tests/files/values.extraction-capture-accounts.yaml
+++ b/src/groundx/tests/files/values.extraction-capture-accounts.yaml
@@ -1,0 +1,4 @@
+integration:
+  extractionCaptureAccounts:
+    - internal-certification-account
+    - second-internal-account

--- a/src/groundx/tests/resources_test.yaml
+++ b/src/groundx/tests/resources_test.yaml
@@ -21,15 +21,14 @@ tests:
       - ../templates/resources/config-yaml.yaml
     values:
       - ../values.yaml
-    set:
-      integration.extractionCaptureAccounts[0]: "internal-certification-account"
+      - ./files/values.extraction-capture-accounts.yaml
     documentSelector:
       path: metadata.name
       value: config-yaml-map
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "integrationTests:[\\s\\S]*extractionCaptureAccounts:[\\s\\S]*- internal-certification-account"
+          pattern: "integrationTests:\\n  extractionCaptureAccounts:\\n\\n    - internal-certification-account\\n    - second-internal-account\\n  search:"
   - it: "default: resources"
     templates:
       - ../templates/resources/config-models.yaml

--- a/src/groundx/tests/resources_test.yaml
+++ b/src/groundx/tests/resources_test.yaml
@@ -4,6 +4,32 @@ chart:
   version: 0.1.0
 
 tests:
+  - it: "extraction capture accounts default to none"
+    templates:
+      - ../templates/resources/config-yaml.yaml
+    values:
+      - ../values.yaml
+    documentSelector:
+      path: metadata.name
+      value: config-yaml-map
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "extractionCaptureAccounts"
+  - it: "configured extraction capture accounts render exactly"
+    templates:
+      - ../templates/resources/config-yaml.yaml
+    values:
+      - ../values.yaml
+    set:
+      integration.extractionCaptureAccounts[0]: "internal-certification-account"
+    documentSelector:
+      path: metadata.name
+      value: config-yaml-map
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "integrationTests:[\\s\\S]*extractionCaptureAccounts:[\\s\\S]*- internal-certification-account"
   - it: "default: resources"
     templates:
       - ../templates/resources/config-models.yaml

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1868,6 +1868,11 @@
     "integration": {
       "type": "object",
       "properties": {
+        "extractionCaptureAccounts": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
         "search": {
           "type": "object",
           "properties": {

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -500,6 +500,9 @@ extract:
         cpu: 200m
         memory: 512Mi
 
+integration:
+  extractionCaptureAccounts: []
+
 throughput:
   tpm:
     document: 12500


### PR DESCRIPTION
Summary

- expose an optional Helm allowlist for extraction capture accounts
- keep the default fail-closed and omit the runtime key when empty
- mirror the source and published chart surfaces
- document rollout, rollback, and protected certification coverage

Testing

- `.build/bin/validate-helm.sh`
- 138 Helm tests and 813 snapshots pass
- invalid types, blank IDs, and duplicate IDs fail schema validation
- configured account lists render exactly

Rollout

After merge, add the approved internal testing account, review the manifest diff, monitor affected rollouts, then run Arcadia legacy, Arcadia v1, generic v1, and ADP v1 certification.