### PR TITLE
Archive extraction capture account plan

### DIFF
--- a/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/design.md
+++ b/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/design.md
@@ -13,5 +13,7 @@ the default and configured render. Schema checks prove invalid values fail.
 The shared ConfigMap hash can roll enabled Go services and metrics. Deploy one
 production Helm revision with the approved internal testing account, wait for
 rollout completion, verify the exact rendered list, and confirm no unrelated
-manifest drift. Roll back by removing the value and upgrading the prior chart
-configuration. No stateful resource changes or migrations occur.
+manifest drift. The hosted GroundX API is a Cashbot Lambda outside this chart;
+when certification uses that endpoint, update its production config and deploy
+it through Cashbot's release path as a separate step. Roll back each surface
+through its owning deployment. No stateful resource changes or migrations occur.

--- a/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/proposal.md
+++ b/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/proposal.md
@@ -15,8 +15,10 @@ Go services and the metrics service. Databases, queues, files, customer data,
 workflow compilation, and extraction behavior are unchanged.
 
 Production rollout sets the approved internal testing account, waits for all
-affected workloads to become ready with zero new restarts, and verifies the
-rendered allowlist before certification. Rollback removes the value and repeats
-the Helm upgrade. No data migration is required.
+affected Helm workloads to become ready with zero new restarts, and verifies the
+rendered allowlist. This chart does not deploy the hosted GroundX Lambda. Hosted
+API certification also requires the Cashbot-owned production config and Lambda
+release path. Rollback removes the value and repeats the owning deployment. No
+data migration is required.
 
 Open design questions: none.

--- a/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/specs/deployment-config/spec.md
+++ b/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/specs/deployment-config/spec.md
@@ -1,32 +1,41 @@
 # Extraction capture account configuration
 
-## Requirement: Capture accounts are explicitly configured
+## ADDED Requirements
+
+### Requirement: Capture accounts are explicitly configured
 
 The chart SHALL expose `integration.extractionCaptureAccounts` as an array of
 unique, non-empty strings. Its default SHALL be empty.
 
-### Scenario: No accounts are configured
+#### Scenario: No accounts are configured
 
 - **GIVEN** the chart's default values
 - **WHEN** the GroundX ConfigMap is rendered
 - **THEN** `integrationTests.extractionCaptureAccounts` is omitted
 - **AND** Cashbot's effective allowlist remains empty
 
-### Scenario: Approved accounts are configured
+#### Scenario: Approved accounts are configured
 
 - **GIVEN** one or more account IDs in `integration.extractionCaptureAccounts`
 - **WHEN** the GroundX ConfigMap is rendered
 - **THEN** `integrationTests.extractionCaptureAccounts` contains those exact IDs
 - **AND** no other account is added
 
-### Scenario: The value has an invalid shape
+#### Scenario: The value has an invalid shape
 
 - **GIVEN** a non-array value, a non-string member, an empty member, or duplicate members
 - **WHEN** Helm validates the values schema
 - **THEN** validation fails before deployment
 
-## Requirement: Capture authorization remains fail closed
+### Requirement: Capture authorization remains fail closed
 
 This chart setting SHALL only supply Cashbot's existing server-side allowlist.
 It SHALL NOT enable capture by itself or alter workflow capture validation,
 expiry, limits, workflow binding, bucket binding, or extraction behavior.
+
+#### Scenario: Certification uses the hosted GroundX API
+
+- **GIVEN** the approved account is rendered into a Helm-managed deployment
+- **WHEN** certification calls the separately deployed hosted GroundX Lambda
+- **THEN** the Helm rollout does not update that Lambda's effective allowlist
+- **AND** its config and code are deployed through Cashbot's owning release path

--- a/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/tasks.md
+++ b/openspec/changes/archive/2026-08-28-configure-extraction-capture-accounts/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Add failing Helm tests for default, configured, and invalid allowlist values.
+- [x] Add the source values, schema, and ConfigMap rendering.
+- [x] Sync the same files into the published Helm mirror.
+- [x] Regenerate snapshots and run `.build/bin/validate-helm.sh`.
+- [x] Review the rendered production diff, deploy the approved account to the Helm-managed services, and verify rollout health.
+- [x] Deploy the same approved account through Cashbot's hosted config and Lambda release path, then verify the effective hosted allowlist.
+- [x] Run the four protected extraction cases in parallel and verify all temporary hosted resources were removed.
+- [x] Archive this change after strict validation.

--- a/openspec/changes/configure-extraction-capture-accounts/tasks.md
+++ b/openspec/changes/configure-extraction-capture-accounts/tasks.md
@@ -1,8 +1,0 @@
-# Tasks
-
-- [x] Add failing Helm tests for default, configured, and invalid allowlist values.
-- [x] Add the source values, schema, and ConfigMap rendering.
-- [x] Sync the same files into the published Helm mirror.
-- [x] Regenerate snapshots and run `.build/bin/validate-helm.sh`.
-- [ ] Review the rendered production diff, deploy the approved account, and verify rollout health.
-- [ ] Run protected extraction certification, remove temporary resources, and archive this change.

--- a/openspec/specs/deployment-config/spec.md
+++ b/openspec/specs/deployment-config/spec.md
@@ -1,0 +1,42 @@
+# deployment-config Specification
+
+## Purpose
+TBD - created by archiving change configure-extraction-capture-accounts. Update Purpose after archive.
+## Requirements
+### Requirement: Capture accounts are explicitly configured
+
+The chart SHALL expose `integration.extractionCaptureAccounts` as an array of
+unique, non-empty strings. Its default SHALL be empty.
+
+#### Scenario: No accounts are configured
+
+- **GIVEN** the chart's default values
+- **WHEN** the GroundX ConfigMap is rendered
+- **THEN** `integrationTests.extractionCaptureAccounts` is omitted
+- **AND** Cashbot's effective allowlist remains empty
+
+#### Scenario: Approved accounts are configured
+
+- **GIVEN** one or more account IDs in `integration.extractionCaptureAccounts`
+- **WHEN** the GroundX ConfigMap is rendered
+- **THEN** `integrationTests.extractionCaptureAccounts` contains those exact IDs
+- **AND** no other account is added
+
+#### Scenario: The value has an invalid shape
+
+- **GIVEN** a non-array value, a non-string member, an empty member, or duplicate members
+- **WHEN** Helm validates the values schema
+- **THEN** validation fails before deployment
+
+### Requirement: Capture authorization remains fail closed
+
+This chart setting SHALL only supply Cashbot's existing server-side allowlist.
+It SHALL NOT enable capture by itself or alter workflow capture validation,
+expiry, limits, workflow binding, bucket binding, or extraction behavior.
+
+#### Scenario: Certification uses the hosted GroundX API
+
+- **GIVEN** the approved account is rendered into a Helm-managed deployment
+- **WHEN** certification calls the separately deployed hosted GroundX Lambda
+- **THEN** the Helm rollout does not update that Lambda's effective allowlist
+- **AND** its config and code are deployed through Cashbot's owning release path


### PR DESCRIPTION
## Summary

- record the completed Helm rollout and parallel protected certification
- document that hosted GroundX Lambda config is deployed separately through Cashbot
- archive the completed OpenSpec change and publish its durable deployment contract

## Validation

- `.build/bin/validate-helm.sh`
- strict OpenSpec validation, 11 of 11 specs passed
- `git diff --check`