### PR TITLE
docs: plan Anthropic workflow engine deployment

### DIFF
--- a/openspec/changes/add-anthropic-workflow-engine-service/.openspec.yaml
+++ b/openspec/changes/add-anthropic-workflow-engine-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/add-anthropic-workflow-engine-service/design.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/design.md
@@ -8,9 +8,12 @@
 cluster-secret inputs carry its configuration. No Anthropic-specific values object,
 secret kind, workload, or network path is added.
 
-The schema already defines `engines.<name>.service`, but `config-yaml.yaml` reads
-`serviceType`. Render `service` first and retain `serviceType` only as a compatibility
-fallback. This makes the documented field effective without adding a value.
+The schema defines `engines.default.service`, while custom engine names are not
+property-validated. `config-yaml.yaml` currently reads `serviceType` for every engine.
+Render documented `service` first and retain `serviceType` only as a compatibility
+fallback. A custom engine that supplies both values currently renders `serviceType`;
+after this correction it renders `service`. Record that precedence change in release
+notes. This makes the documented field effective without adding a value.
 
 The chart selects configuration only. The matching application image owns native
 Messages API transport and response handling.
@@ -26,7 +29,8 @@ external model service from the in-cluster EyeLevel service. For Anthropic:
 - do not inject local-model kwargs or reasoning defaults; and
 - preserve the exact lowercase service value in generated application configuration.
 
-Other service values keep their current behavior.
+Other service values keep their current behavior except for the explicit per-engine
+`service` precedence correction above.
 
 ## Credentials
 
@@ -52,12 +56,16 @@ may be released only with application image versions that understand native Anth
 Canary one text summary and one multimodal extraction-agent request using existing
 secret handling before production assignment.
 
-No stateful migration or zero-downtime coordination is required. Failure affects only
-opted-in model calls. Rollback restores the prior service selection or image while
+No stateful migration or zero-downtime coordination is required. Anthropic failures
+affect opted-in model calls; the per-engine precedence correction can also affect a
+non-Anthropic custom engine that sets `service`, especially when it also sets
+`serviceType`. Rollback restores the prior chart, service selection, or image while
 leaving stored `anthropic` values readable upstream.
 
 ## Validation
 
 Add render and failure tests for both summary and extraction-agent paths, including
-credential sources and absent required configuration. Run the full Helm gate, a normal
-minikube render, strict OpenSpec validation, mirror comparison, and `git diff --check`.
+credential sources and absent required configuration. Add one custom-engine case with
+conflicting `service` and `serviceType` values and prove documented `service` wins; do
+not add a separate legacy-only fixture. Run the full Helm gate, a normal minikube
+render, strict OpenSpec validation, mirror comparison, and `git diff --check`.

--- a/openspec/changes/add-anthropic-workflow-engine-service/design.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/design.md
@@ -45,9 +45,12 @@ secret name, or environment variable.
 
 ## Source and mirror
 
-Implement in `src/groundx` first. Regenerate snapshots through Helm tooling, then copy
-the matching changed source files into `helm` because that directory is the manually
-maintained published mirror. Compare both surfaces after synchronization.
+Base the plan and implementation on current pushed `origin/0.2.7`, the active chart
+release line. Do not use `origin/main` as the base: its chart templates, schema, and
+validation script have diverged from the release line. Implement in `src/groundx`
+first. Regenerate snapshots through Helm tooling, then copy the matching changed source
+files into `helm` because that directory is the manually maintained published mirror.
+Compare both surfaces after synchronization.
 
 ## Deployment
 

--- a/openspec/changes/add-anthropic-workflow-engine-service/design.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/design.md
@@ -1,0 +1,63 @@
+# Design
+
+## Reuse the existing service shape
+
+`anthropic` is another value of the current service selectors. Summary continues to use
+`summary.existing` and `engines.<name>`; extraction agents continue to use
+`extract.agent`. Existing URL, endpoint, engine ID, API-key, existing-secret, and
+cluster-secret inputs carry its configuration. No Anthropic-specific values object,
+secret kind, workload, or network path is added.
+
+The schema already defines `engines.<name>.service`, but `config-yaml.yaml` reads
+`serviceType`. Render `service` first and retain `serviceType` only as a compatibility
+fallback. This makes the documented field effective without adding a value.
+
+The chart selects configuration only. The matching application image owns native
+Messages API transport and response handling.
+
+## Provider classification
+
+Add exact `anthropic` wherever summary or extraction-agent templates distinguish an
+external model service from the in-cluster EyeLevel service. For Anthropic:
+
+- render the operator-supplied summary URL or per-engine base URL and engine ID, and
+  the extraction-agent endpoint and model;
+- do not synthesize the in-cluster summary endpoint or model;
+- do not inject local-model kwargs or reasoning defaults; and
+- preserve the exact lowercase service value in generated application configuration.
+
+Other service values keep their current behavior.
+
+## Credentials
+
+Anthropic must use the existing provider credential paths. Summary accepts
+`summary.existing.apiKey` as its baseline or an `engines.<name>.apiKey` override.
+Extraction accepts its existing `apiKey`, `existingSecret`, or `cluster.secrets`
+source. Missing effective Anthropic credentials fail chart validation instead of using
+`admin.apiKey`.
+
+Templates and tests must not print credential values. This change adds no secret data,
+secret name, or environment variable.
+
+## Source and mirror
+
+Implement in `src/groundx` first. Regenerate snapshots through Helm tooling, then copy
+the matching changed source files into `helm` because that directory is the manually
+maintained published mirror. Compare both surfaces after synchronization.
+
+## Deployment
+
+Merge after the Fern service contract and Cashbot runtime behavior are settled. A chart
+may be released only with application image versions that understand native Anthropic.
+Canary one text summary and one multimodal extraction-agent request using existing
+secret handling before production assignment.
+
+No stateful migration or zero-downtime coordination is required. Failure affects only
+opted-in model calls. Rollback restores the prior service selection or image while
+leaving stored `anthropic` values readable upstream.
+
+## Validation
+
+Add render and failure tests for both summary and extraction-agent paths, including
+credential sources and absent required configuration. Run the full Helm gate, a normal
+minikube render, strict OpenSpec validation, mirror comparison, and `git diff --check`.

--- a/openspec/changes/add-anthropic-workflow-engine-service/proposal.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/proposal.md
@@ -1,0 +1,56 @@
+# Add Anthropic to the existing external engine configuration
+
+## Why
+
+The shared workflow contract will add `service: anthropic`. The chart currently treats
+that value as an in-cluster summary or extraction agent service, substitutes internal
+defaults, and can fall back to the GroundX admin key. Its schema also calls the
+per-engine field `service`, while the renderer reads `serviceType`. That does not
+configure a native Anthropic runtime safely.
+
+## Blast Radius
+
+Only deployments that select `anthropic` for `summary.existing.serviceType` or
+`extract.agent.serviceType` change. Existing service selections, Kubernetes resources,
+stateful services, queues, and default deployments remain unchanged. Enabling Anthropic
+changes outbound model traffic and requires an Anthropic endpoint, model, and credential.
+
+## What Changes
+
+- Recognize exact `anthropic` as an external provider in the existing summary and
+  extraction-agent service selectors. Render the schema's existing per-engine
+  `service` field instead of silently ignoring it.
+- Reuse summary's existing URL, API key, and per-engine fields, plus the extraction
+  agent's existing endpoint, model, API key, existing-secret, and cluster-secret
+  configuration. Add no chart value.
+- Require an explicit Anthropic credential source. Never substitute the GroundX admin
+  API key.
+- Prevent in-cluster endpoint, model, kwargs, and reasoning defaults from being applied
+  to Anthropic.
+- Keep `src/groundx` authoritative and synchronize the matching published `helm` mirror.
+
+## Capabilities
+
+### New Capabilities
+
+- `anthropic-workflow-engine-service`: the chart can configure existing summary and
+  extraction-agent workloads for a runtime image that natively supports Anthropic.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Templates: summary and extraction-agent provider classification, validation,
+  per-engine service rendering, and credential selection.
+- Values contract: no new or renamed field.
+- Images: no application image is built here. A chart release is blocked until its
+  referenced runtime images support native Anthropic.
+- Environments: dev, staging, and production only when an operator opts into
+  `anthropic`.
+- Data and stateful resources: none.
+- Rollout: render and canary with a matching immutable runtime image before production.
+  Roll back by restoring the prior service selection and secret while keeping the
+  additive public enum readable.
+- Open design questions: none.

--- a/openspec/changes/add-anthropic-workflow-engine-service/proposal.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/proposal.md
@@ -45,6 +45,9 @@ None.
 
 ## Impact
 
+- Branch: base the plan and implementation on current pushed `origin/0.2.7`, the active
+  chart release line. Do not carry `origin/main` history or validate against its older
+  chart and CI surfaces.
 - Templates: summary and extraction-agent provider classification, validation,
   per-engine service rendering, and credential selection.
 - Values contract: no new or renamed field.

--- a/openspec/changes/add-anthropic-workflow-engine-service/proposal.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/proposal.md
@@ -10,10 +10,13 @@ configure a native Anthropic runtime safely.
 
 ## Blast Radius
 
-Only deployments that select `anthropic` for `summary.existing.serviceType` or
-`extract.agent.serviceType` change. Existing service selections, Kubernetes resources,
-stateful services, queues, and default deployments remain unchanged. Enabling Anthropic
-changes outbound model traffic and requires an Anthropic endpoint, model, and credential.
+Deployments that select `anthropic` for `summary.existing.serviceType` or
+`extract.agent.serviceType` change. Per-engine summary configuration also changes when
+it sets the documented `engines.<name>.service`: that value becomes effective. For a
+non-default custom engine that supplies both `service` and the legacy `serviceType`,
+documented `service` becomes authoritative instead of `serviceType`. Defaults and
+engines that set neither field remain unchanged. Enabling Anthropic changes outbound
+model traffic and requires an Anthropic endpoint, model, and credential.
 
 ## What Changes
 
@@ -47,10 +50,12 @@ None.
 - Values contract: no new or renamed field.
 - Images: no application image is built here. A chart release is blocked until its
   referenced runtime images support native Anthropic.
-- Environments: dev, staging, and production only when an operator opts into
-  `anthropic`.
+- Environments: dev, staging, and production when an operator opts into `anthropic` or
+  already supplies per-engine `service`; conflicting custom-engine values follow the
+  documented `service` field after upgrade.
 - Data and stateful resources: none.
 - Rollout: render and canary with a matching immutable runtime image before production.
-  Roll back by restoring the prior service selection and secret while keeping the
-  additive public enum readable.
+  Release notes call out the per-engine precedence correction. Roll back by restoring
+  the prior chart or service selection and secret while keeping the additive public
+  enum readable.
 - Open design questions: none.

--- a/openspec/changes/add-anthropic-workflow-engine-service/specs/anthropic-workflow-engine-service/spec.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/specs/anthropic-workflow-engine-service/spec.md
@@ -49,16 +49,26 @@ and MUST NOT fall back to the GroundX admin API key.
 - **Then** rendering fails with a configuration error
 - **And** the admin API key is not used
 
-### Requirement: Existing providers remain stable
+### Requirement: Existing providers remain stable outside the documented precedence correction
 
 The chart MUST retain the current rendered behavior for every existing service value
-and for deployments that do not select Anthropic.
+and for deployments that do not select Anthropic, except that documented per-engine
+`service` becomes effective and takes precedence over legacy `serviceType`.
+
+#### Scenario: Documented per-engine service wins
+
+- **Given** a custom non-default engine supplies conflicting `service` and
+  `serviceType` values
+- **When** the chart renders application configuration
+- **Then** the documented `service` value is rendered
+- **And** the chart release notes identify the upgrade behavior change.
 
 #### Scenario: Existing service regression suite
 
 - **Given** the existing service fixtures and default values
 - **When** the full Helm validation gate runs
-- **Then** their provider routing and credential behavior remain unchanged
+- **Then** their provider routing and credential behavior remain unchanged outside the
+  explicit per-engine precedence correction
 
 ### Requirement: Chart and runtime support are released together
 

--- a/openspec/changes/add-anthropic-workflow-engine-service/specs/anthropic-workflow-engine-service/spec.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/specs/anthropic-workflow-engine-service/spec.md
@@ -1,0 +1,74 @@
+# Anthropic workflow engine service
+
+## ADDED Requirements
+
+### Requirement: Anthropic is an external model service
+
+The chart MUST preserve exact `serviceType: anthropic` and configure it as an external
+provider for summary and extraction-agent workloads.
+
+#### Scenario: Summary selects Anthropic
+
+- **Given** summary existing-service or per-engine values select `anthropic`
+- **When** the chart renders application configuration
+- **Then** the exact service, supplied summary URL or engine base URL, and engine ID
+  are rendered
+- **And** no in-cluster summary endpoint or model is substituted
+
+#### Scenario: Per-engine service uses the schema field
+
+- **Given** `engines.<name>.service` is `anthropic`
+- **When** the chart renders application configuration
+- **Then** that engine's service is exactly `anthropic`
+- **And** the renderer does not ignore the schema field in favor of the summary default
+
+#### Scenario: Extraction agent selects Anthropic
+
+- **Given** extraction-agent values select `anthropic`
+- **When** the chart renders application configuration
+- **Then** the exact service, supplied endpoint, and supplied model are rendered
+- **And** no in-cluster endpoint, model, kwargs, or reasoning default is substituted
+
+### Requirement: Anthropic uses explicit provider credentials
+
+The chart MUST require an existing supported provider-credential source for Anthropic
+and MUST NOT fall back to the GroundX admin API key.
+
+#### Scenario: Existing credential sources work
+
+- **Given** Anthropic is selected with a supported summary or extraction credential
+  source
+- **When** the chart renders
+- **Then** it passes that source through the existing credential contract
+- **And** it does not substitute the GroundX admin API key
+
+#### Scenario: Credential is missing
+
+- **Given** Anthropic is selected without a supported provider credential
+- **When** the chart renders
+- **Then** rendering fails with a configuration error
+- **And** the admin API key is not used
+
+### Requirement: Existing providers remain stable
+
+The chart MUST retain the current rendered behavior for every existing service value
+and for deployments that do not select Anthropic.
+
+#### Scenario: Existing service regression suite
+
+- **Given** the existing service fixtures and default values
+- **When** the full Helm validation gate runs
+- **Then** their provider routing and credential behavior remain unchanged
+
+### Requirement: Chart and runtime support are released together
+
+The chart MUST NOT advertise or release Anthropic configuration with an application
+image that lacks the matching native provider adapter.
+
+#### Scenario: Release is prepared
+
+- **Given** the chart recognizes Anthropic
+- **When** a release candidate is assembled
+- **Then** its immutable runtime image versions are recorded as supporting native
+  Anthropic
+- **And** a text and multimodal canary pass before production assignment

--- a/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
@@ -5,7 +5,8 @@
 - [ ] 1.1 Add failing summary tests showing `anthropic` is currently classified as
   in-cluster and can inherit the wrong endpoint or credential.
 - [ ] 1.2 Add a failing render test proving the schema-supported
-  `engines.<name>.service` field is currently ignored.
+  `engines.<name>.service` field is currently ignored, plus one custom non-default
+  engine case proving legacy `serviceType` currently wins when both values disagree.
 - [ ] 1.3 Add failing extraction-agent tests for endpoint, model, kwargs, reasoning,
   exact service value, and credential selection.
 - [ ] 1.4 Add failure cases for missing effective Anthropic endpoint, engine ID or
@@ -16,7 +17,8 @@
 - [ ] 2.1 Add exact `anthropic` to the external-service checks in the authoritative
   `src/groundx` summary and extraction-agent helpers.
 - [ ] 2.2 Render the existing `engines.<name>.service` schema field, retaining
-  `serviceType` only as a compatibility fallback.
+  `serviceType` only as a compatibility fallback. Prove documented `service` wins when
+  a custom engine supplies both values; add no separate `serviceType`-only fixture.
 - [ ] 2.3 Reuse existing URL, endpoint, engine, model, and credential fields. Add no
   values or schema properties.
 - [ ] 2.4 Require effective Anthropic credentials and prevent `admin.apiKey` fallback.
@@ -28,7 +30,8 @@
 - [ ] 3.2 Copy the matching changed source templates and contract files into the
   published `helm` mirror and compare both surfaces.
 - [ ] 3.3 Update concise values guidance for the existing fields without adding
-  credentials or a second configuration shape.
+  credentials or a second configuration shape. Add a release note that per-engine
+  `service` now takes effect and wins over legacy `serviceType` when both are present.
 
 ## 4. Validate and release safely
 
@@ -39,5 +42,8 @@
   images that support native Anthropic.
 - [ ] 4.3 Canary one text summary and one multimodal extraction-agent request with no
   credential values in evidence.
-- [ ] 4.4 Roll out only to opted-in environments. Roll back provider assignment or the
-  runtime image without removing the additive service value.
+- [ ] 4.4 Roll out Anthropic only to opted-in environments. Before chart release,
+  identify any non-Anthropic custom-engine values that set `service` or both service
+  keys, review the rendered precedence change, and include it in the upgrade notes.
+  Roll back the chart, provider assignment, or runtime image without removing the
+  additive service value.

--- a/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
@@ -1,0 +1,43 @@
+# Anthropic workflow engine service implementation plan
+
+## 1. Lock current failure with render tests
+
+- [ ] 1.1 Add failing summary tests showing `anthropic` is currently classified as
+  in-cluster and can inherit the wrong endpoint or credential.
+- [ ] 1.2 Add a failing render test proving the schema-supported
+  `engines.<name>.service` field is currently ignored.
+- [ ] 1.3 Add failing extraction-agent tests for endpoint, model, kwargs, reasoning,
+  exact service value, and credential selection.
+- [ ] 1.4 Add failure cases for missing effective Anthropic endpoint, engine ID or
+  model, and credential.
+
+## 2. Extend the existing service selectors
+
+- [ ] 2.1 Add exact `anthropic` to the external-service checks in the authoritative
+  `src/groundx` summary and extraction-agent helpers.
+- [ ] 2.2 Render the existing `engines.<name>.service` schema field, retaining
+  `serviceType` only as a compatibility fallback.
+- [ ] 2.3 Reuse existing URL, endpoint, engine, model, and credential fields. Add no
+  values or schema properties.
+- [ ] 2.4 Require effective Anthropic credentials and prevent `admin.apiKey` fallback.
+- [ ] 2.5 Preserve every existing provider branch and unknown-service behavior.
+
+## 3. Synchronize generated and published surfaces
+
+- [ ] 3.1 Regenerate affected Helm unit snapshots. Do not edit snapshots manually.
+- [ ] 3.2 Copy the matching changed source templates and contract files into the
+  published `helm` mirror and compare both surfaces.
+- [ ] 3.3 Update concise values guidance for the existing fields without adding
+  credentials or a second configuration shape.
+
+## 4. Validate and release safely
+
+- [ ] 4.1 Run `.build/bin/validate-helm.sh`, `helm template src/groundx -f
+  src/groundx/values/minikube/values.yaml`, strict OpenSpec validation, and `git diff
+  --check`.
+- [ ] 4.2 Record the Fern and Cashbot prerequisite versions and the immutable application
+  images that support native Anthropic.
+- [ ] 4.3 Canary one text summary and one multimodal extraction-agent request with no
+  credential values in evidence.
+- [ ] 4.4 Roll out only to opted-in environments. Roll back provider assignment or the
+  runtime image without removing the additive service value.

--- a/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
@@ -1,5 +1,11 @@
 # Anthropic workflow engine service implementation plan
 
+## Global constraints
+
+- Base the plan and implementation on current pushed `origin/0.2.7` in an isolated
+  worktree. Carry only this OpenSpec change and its eventual implementation; do not
+  include `origin/main`-only commits.
+
 ## 1. Lock current failure with render tests
 
 - [ ] 1.1 Add failing summary tests showing `anthropic` is currently classified as


### PR DESCRIPTION
## Summary

* Add an OpenSpec plan for exact `anthropic` handling in existing summary and extraction-agent service selectors.
* Use the existing service, endpoint, model, and credential fields.
* Prevent Anthropic engines from receiving in-cluster defaults or admin-key fallback.
* Preserve `serviceType` as a compatibility fallback while rendering the canonical `service` field.

## Validation

`OPENSPEC_TELEMETRY=0 npx -y @fission-ai/openspec@1.3.1 validate add-anthropic-workflow-engine-service --strict`

## Scope

Plan only. No chart or deployment behavior changed in this PR.

Related to AGE-336.