### PR TITLE
docs: explain extract model request overrides

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -19,3 +19,20 @@ The following table lists the configurable parameters of the GroundX chart and t
 | `admin.password`                            | The email associated with the admin account in this deployment                  | `password`                            |
 | `extract.terminalAgentTraceEnabled`         | Enables terminal-only private diagnostics for every extract pod                  | `false`                               |
 | `extract.<pod>.terminalAgentTraceEnabled`   | Overrides the shared diagnostic value for api, agent, download, or save           | inherited                             |
+
+## Extract model request overrides
+
+Use the existing extraction-agent model kwargs for provider request-body options:
+
+```yaml
+extract:
+  agent:
+    model:
+      kwargs:
+        extra_body:
+          parallel_tool_calls: false
+```
+
+This example makes the extraction model call one tool per turn. Workflow
+`requestPassthrough` values override matching `extra_body` defaults. The selected
+extraction runtime image must support the option.

--- a/src/groundx/README.md
+++ b/src/groundx/README.md
@@ -17,3 +17,20 @@ The following table lists the configurable parameters of the GroundX chart and t
 | `admin.username`                            | A UUID that will be associated with the admin account in this deployment        | `00000000-0000-0000-0000-000000000000`|
 | `admin.email`                               | The password associated with the admin account in this deployment               | `support@mycorp.net`                  |
 | `admin.password`                            | The email associated with the admin account in this deployment                  | `password`                            |
+
+## Extract model request overrides
+
+Use the existing extraction-agent model kwargs for provider request-body options:
+
+```yaml
+extract:
+  agent:
+    model:
+      kwargs:
+        extra_body:
+          parallel_tool_calls: false
+```
+
+This example makes the extraction model call one tool per turn. Workflow
+`requestPassthrough` values override matching `extra_body` defaults. The selected
+extraction runtime image must support the option.

--- a/src/groundx/tests/extract_test.yaml
+++ b/src/groundx/tests/extract_test.yaml
@@ -724,6 +724,7 @@ tests:
     set:
       extract.agent.model.kwargs.client_kwargs.max_retries: 1
       extract.agent.model.kwargs.client_kwargs.timeout: 180
+      extract.agent.model.kwargs.extra_body.parallel_tool_calls: false
     asserts:
       - matchRegex:
           path: stringData["config.py"]
@@ -731,6 +732,9 @@ tests:
       - matchRegex:
           path: stringData["config.py"]
           pattern: '"client_kwargs": \{[^}]*"timeout": 180'
+      - matchRegex:
+          path: stringData["config.py"]
+          pattern: '"extra_body": \{[^}]*"parallel_tool_calls": False'
   - it: "extract-agent hpa keeps a safer default minimum"
     templates:
       - ../templates/resources/hpa.yaml

--- a/src/groundx/tests/resources_test.yaml
+++ b/src/groundx/tests/resources_test.yaml
@@ -27,7 +27,7 @@ tests:
       value: config-yaml-map
     asserts:
       - matchRegex:
-          path: data["config.yaml"]
+          path: stringData["config.yaml"]
           pattern: "integrationTests:\\n  extractionCaptureAccounts:\\n\\n    - internal-certification-account\\n    - second-internal-account\\n  search:"
   - it: "default: resources"
     templates:


### PR DESCRIPTION
## Summary
Document the existing extraction-agent model request overrides and test that nested extra_body values render correctly. Workflow requestPassthrough values override matching deployment defaults. No chart template, schema, or runtime behavior changes.

Includes current 0.2.7 and preserves explicit-engine documentation.

## Validation
- Full Helm gate passed: 254 tests, 815 snapshots, source and published-chart render checks.
- Minikube render passed.
- Rendered settings exercised through current Internal Arcadia provider configuration and document-review request functions: false is retained, and workflow true overrides it.
- No live provider call or deployment.