### PR TITLE
AGE-344: configure managed project data

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ Workspace project metadata and operation state are stored in MySQL. The primary 
 
 Publish is dry-run by default. To enable real publish, set `workspace.publishDryRun: false`, configure the provider credentials owned by the runner service, and set the workflow or pipeline to trigger. For GitHub Actions:
 
+Managed project data is also disabled by default. For the hosted AWS path, set `workspace.managedData.enabled: true`, its AWS region, and the dev and prod S3 bucket, Redis endpoint, and Redis user-group values. Use `workspace.existingSecret`; it must contain `WORKSPACE_RUNNER_TOKEN`, `MANAGED_DATA_RDS_ADMIN_CONNECTION_DEV`, and `MANAGED_DATA_RDS_ADMIN_CONNECTION_PROD`. Keep the RDS administrator URLs out of values files. Grant every Workspace component service account the least-privilege AWS permissions needed to manage the configured S3 prefixes, IAM users, and ElastiCache users. Enable dev first and verify allocation, republish, isolation, and confirmed deletion before enabling prod. Disabling the setting stops new reconciliation but does not delete existing app data.
+
 ```yaml
 workspace:
   enabled: true

--- a/helm/templates/_helpers/app/groundx.tpl
+++ b/helm/templates/_helpers/app/groundx.tpl
@@ -230,11 +230,7 @@ false
 
 {{- $rep := (include "groundx.groundx.replicas" . | fromYaml) -}}
 {{- $san := include "groundx.groundx.serviceAccountName" . -}}
-{{- $secrets := dict -}}
 {{- $wrc := include "groundx.workspace.create" . -}}
-{{- if and (eq $wrc "true") (or (ne (include "groundx.workspace.existingSecret" .) "") (ne (include "groundx.workspace.token" .) "")) -}}
-{{- $_ := set $secrets (include "groundx.workspace.secretName" .) (include "groundx.workspace.secretName" .) -}}
-{{- end -}}
 
 {{- $cfg := dict
   "dependencies" $dpnd
@@ -246,11 +242,11 @@ false
   "pull"         (include "groundx.groundx.imagePullPolicy" .)
   "replicas"     ($rep)
 -}}
-{{- if gt (len $secrets) 0 -}}
-  {{- $_ := set $cfg "secrets" $secrets -}}
-{{- end -}}
 {{- if eq $wrc "true" -}}
-  {{- $_ := set $cfg "env" (list (dict "name" "WORKSPACE_RUNNER_BASE_URL" "value" (include "groundx.workspace.api.serviceUrl" .))) -}}
+  {{- $_ := set $cfg "env" (list
+    (dict "name" "WORKSPACE_RUNNER_BASE_URL" "value" (include "groundx.workspace.api.serviceUrl" .))
+    (dict "name" "WORKSPACE_RUNNER_TOKEN" "valueFrom" (dict "secretKeyRef" (dict "name" (include "groundx.workspace.secretName" .) "key" "WORKSPACE_RUNNER_TOKEN")))
+  ) -}}
 {{- end -}}
 {{- if and $san (ne $san "") -}}
   {{- $_ := set $cfg "serviceAccountName" $san -}}

--- a/helm/templates/_helpers/app/workspace.tpl
+++ b/helm/templates/_helpers/app/workspace.tpl
@@ -14,6 +14,10 @@
     {{- if and (eq (dig "token" "" $in) "") (eq (dig "existingSecret" "" $in) "") -}}
       {{- fail "workspace requires workspace.token or workspace.existingSecret when enabled" -}}
     {{- end -}}
+    {{- $managedData := dig "managedData" dict $in -}}
+    {{- if and (dig "enabled" false $managedData) (eq (dig "existingSecret" "" $in) "") -}}
+      {{- fail "workspace managed data requires workspace.existingSecret" -}}
+    {{- end -}}
 true
   {{- else -}}false{{- end -}}
 {{- else -}}
@@ -181,6 +185,41 @@ false
 {{- define "groundx.workspace.managedRepoVisibility" -}}
 {{- $in := include "groundx.workspace.values" . | fromYaml -}}
 {{ dig "managedRepoVisibility" "private" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData" -}}
+{{- $in := include "groundx.workspace.values" . | fromYaml -}}
+{{ dig "managedData" dict $in | toYaml }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.enabled" -}}
+{{- $in := include "groundx.workspace.managedData" . | fromYaml -}}
+{{ dig "enabled" false $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.awsRegion" -}}
+{{- $in := include "groundx.workspace.managedData" . | fromYaml -}}
+{{ dig "awsRegion" "" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.environment" -}}
+{{- $managed := include "groundx.workspace.managedData" .root | fromYaml -}}
+{{ dig .environment dict $managed | toYaml }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.s3Bucket" -}}
+{{- $in := include "groundx.workspace.managedData.environment" . | fromYaml -}}
+{{ dig "s3Bucket" "" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.redisEndpoint" -}}
+{{- $in := include "groundx.workspace.managedData.environment" . | fromYaml -}}
+{{ dig "redisEndpoint" "" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.redisUserGroup" -}}
+{{- $in := include "groundx.workspace.managedData.environment" . | fromYaml -}}
+{{ dig "redisUserGroup" "" $in }}
 {{- end }}
 
 {{- define "groundx.workspace.token" -}}

--- a/helm/templates/resources/workspace-config-py.yaml
+++ b/helm/templates/resources/workspace-config-py.yaml
@@ -37,6 +37,18 @@ data:
         managed_repo_name_prefix={{ include "groundx.workspace.managedRepoNamePrefix" . | quote }},
         managed_repo_owner={{ include "groundx.workspace.managedRepoOwner" . | quote }},
         managed_repo_visibility={{ include "groundx.workspace.managedRepoVisibility" . | quote }},
+{{- if eq (printf "%v" (include "groundx.workspace.managedData.enabled" .)) "true" }}
+        managed_data_enabled={{ if eq (printf "%v" (include "groundx.workspace.managedData.enabled" .)) "true" }}True{{ else }}False{{ end }},
+        managed_data_aws_region={{ include "groundx.workspace.managedData.awsRegion" . | quote }},
+        managed_data_rds_admin_connection_dev="",
+        managed_data_rds_admin_connection_prod="",
+        managed_data_s3_bucket_dev={{ include "groundx.workspace.managedData.s3Bucket" (dict "root" . "environment" "dev") | quote }},
+        managed_data_s3_bucket_prod={{ include "groundx.workspace.managedData.s3Bucket" (dict "root" . "environment" "prod") | quote }},
+        managed_data_redis_endpoint_dev={{ include "groundx.workspace.managedData.redisEndpoint" (dict "root" . "environment" "dev") | quote }},
+        managed_data_redis_endpoint_prod={{ include "groundx.workspace.managedData.redisEndpoint" (dict "root" . "environment" "prod") | quote }},
+        managed_data_redis_user_group_dev={{ include "groundx.workspace.managedData.redisUserGroup" (dict "root" . "environment" "dev") | quote }},
+        managed_data_redis_user_group_prod={{ include "groundx.workspace.managedData.redisUserGroup" (dict "root" . "environment" "prod") | quote }},
+{{- end }}
         mysql_connect_timeout_seconds={{ include "groundx.workspace.mysqlConnectTimeoutSeconds" . }},
         mysql_database={{ include "groundx.db.dbName" . | quote }},
         mysql_host={{ include "groundx.db.rw" . | quote }},

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1481,6 +1481,33 @@
         "managedRepoNamePrefix": { "type": "string" },
         "managedRepoOwner": { "type": "string" },
         "managedRepoVisibility": { "type": "string" },
+        "managedData": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "awsRegion": { "type": "string" },
+            "dev": {
+              "type": "object",
+              "properties": {
+                "s3Bucket": { "type": "string" },
+                "redisEndpoint": { "type": "string" },
+                "redisUserGroup": { "type": "string" }
+              },
+              "additionalProperties": false
+            },
+            "prod": {
+              "type": "object",
+              "properties": {
+                "s3Bucket": { "type": "string" },
+                "redisEndpoint": { "type": "string" },
+                "redisUserGroup": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["enabled"],
+          "additionalProperties": false
+        },
         "mysqlConnectTimeoutSeconds": { "type": "integer" },
         "node": { "type": "string" },
         "publishGithubWorkflowId": { "type": "string" },

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -357,6 +357,20 @@ workspace:
   gitProvider: github
   publishGithubWorkflowId: deploy.yml
 
+  # Hosted AWS logical allocation. RDS administrator URLs must be supplied by
+  # existingSecret as MANAGED_DATA_RDS_ADMIN_CONNECTION_DEV and _PROD.
+  managedData:
+    enabled: false
+    awsRegion: ""
+    dev:
+      s3Bucket: ""
+      redisEndpoint: ""
+      redisUserGroup: ""
+    prod:
+      s3Bucket: ""
+      redisEndpoint: ""
+      redisUserGroup: ""
+
   github:
     apiBaseUrl: https://api.github.com
     appId: ""

--- a/openspec/changes/add-workspace-managed-data-config/.openspec.yaml
+++ b/openspec/changes/add-workspace-managed-data-config/.openspec.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/changes/add-workspace-managed-data-config/design.md
+++ b/openspec/changes/add-workspace-managed-data-config/design.md
@@ -1,0 +1,7 @@
+# Design
+
+Add one `workspace.managedData` block. The chart writes only the enable flag, AWS region, S3 bucket names, Redis endpoints, and Redis user-group IDs into `config.py`. RDS administrator URLs stay out of values and come from `workspace.existingSecret` as `MANAGED_DATA_RDS_ADMIN_CONNECTION_DEV` and `MANAGED_DATA_RDS_ADMIN_CONNECTION_PROD`.
+
+The Workspace service account supplies the runner's AWS control-plane identity. The runner creates app-scoped credentials and injects them into each app's existing GitHub environment secret boundary. No new Kubernetes workload or provider abstraction is added.
+
+Rollout dev first with a pre-created secret and least-privilege service-account role. Verify allocation, republish, isolation, and confirmed deletion, then enable prod. Disabling the flag stops new reconciliation but preserves existing data. This chart change performs no stateful migration and causes only Workspace pods to roll.

--- a/openspec/changes/add-workspace-managed-data-config/proposal.md
+++ b/openspec/changes/add-workspace-managed-data-config/proposal.md
@@ -1,0 +1,7 @@
+# Add Workspace managed-data configuration
+
+The Workspace runner already accepts managed-data configuration, but the Helm chart cannot supply it. When managed data is enabled, every Workspace API and worker pod must receive the same non-secret AWS resource settings and the existing Workspace secret must supply the two RDS administrator URLs.
+
+This changes only Workspace pods. It does not create, modify, or delete RDS, S3, Redis, IAM, Kubernetes, or cloud resources. Existing installs remain disabled by default. Rollback disables the setting and restores the prior runner image without deleting allocations.
+
+Affected environments: any dev or prod cluster that explicitly enables the setting. Open questions: none.

--- a/openspec/changes/add-workspace-managed-data-config/specs/workspace-managed-data/spec.md
+++ b/openspec/changes/add-workspace-managed-data-config/specs/workspace-managed-data/spec.md
@@ -1,0 +1,44 @@
+# Workspace managed-data configuration
+
+## ADDED Requirements
+
+### Requirement: Managed data is disabled by default
+
+The chart SHALL keep Workspace managed data disabled unless an operator explicitly enables it.
+
+#### Scenario: Existing values render unchanged
+
+- **GIVEN** existing chart values
+- **WHEN** the chart renders
+- **THEN** Workspace settings disable managed data and require no provider configuration
+
+### Requirement: Provider settings reach every Workspace process
+
+The chart SHALL render the configured non-secret provider settings into the shared Workspace settings file.
+
+#### Scenario: Enabled settings render
+
+- **GIVEN** `workspace.managedData.enabled: true`
+- **WHEN** the chart renders
+- **THEN** the shared Workspace `config.py` contains the configured AWS region, environment-specific S3 buckets, Redis endpoints, and Redis user groups
+
+### Requirement: Administrator credentials remain secret
+
+The chart SHALL obtain RDS administrator URLs only from the existing Workspace Kubernetes Secret.
+
+#### Scenario: RDS administrator URLs stay out of ConfigMaps
+
+- **GIVEN** managed data is enabled
+- **WHEN** the chart renders
+- **THEN** no RDS administrator URL appears in a ConfigMap or committed values file
+- **AND** Workspace pods obtain those URLs only from `workspace.existingSecret`
+
+### Requirement: The deployment contract is strict and mirrored
+
+The source and published chart surfaces SHALL expose the same strict managed-data values contract.
+
+#### Scenario: Both chart surfaces validate
+
+- **GIVEN** the new values
+- **WHEN** schema validation and Helm tests run
+- **THEN** the source and published chart surfaces accept the same block and render the same Workspace configuration

--- a/openspec/changes/add-workspace-managed-data-config/tasks.md
+++ b/openspec/changes/add-workspace-managed-data-config/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Add failing Helm tests for disabled defaults, enabled provider settings, and secret-only RDS administrator URLs.
+- [x] Add the strict values schema, defaults, helpers, and Workspace config rendering.
+- [x] Mirror source chart changes into `helm/`.
+- [x] Run Helm unit, lint, render, schema, and mirror validation.
+- [x] Document dev-first rollout and the required secret and service-account identity.

--- a/src/groundx/templates/_helpers/app/groundx.tpl
+++ b/src/groundx/templates/_helpers/app/groundx.tpl
@@ -230,11 +230,7 @@ false
 
 {{- $rep := (include "groundx.groundx.replicas" . | fromYaml) -}}
 {{- $san := include "groundx.groundx.serviceAccountName" . -}}
-{{- $secrets := dict -}}
 {{- $wrc := include "groundx.workspace.create" . -}}
-{{- if and (eq $wrc "true") (or (ne (include "groundx.workspace.existingSecret" .) "") (ne (include "groundx.workspace.token" .) "")) -}}
-{{- $_ := set $secrets (include "groundx.workspace.secretName" .) (include "groundx.workspace.secretName" .) -}}
-{{- end -}}
 
 {{- $cfg := dict
   "dependencies" $dpnd
@@ -246,11 +242,11 @@ false
   "pull"         (include "groundx.groundx.imagePullPolicy" .)
   "replicas"     ($rep)
 -}}
-{{- if gt (len $secrets) 0 -}}
-  {{- $_ := set $cfg "secrets" $secrets -}}
-{{- end -}}
 {{- if eq $wrc "true" -}}
-  {{- $_ := set $cfg "env" (list (dict "name" "WORKSPACE_RUNNER_BASE_URL" "value" (include "groundx.workspace.api.serviceUrl" .))) -}}
+  {{- $_ := set $cfg "env" (list
+    (dict "name" "WORKSPACE_RUNNER_BASE_URL" "value" (include "groundx.workspace.api.serviceUrl" .))
+    (dict "name" "WORKSPACE_RUNNER_TOKEN" "valueFrom" (dict "secretKeyRef" (dict "name" (include "groundx.workspace.secretName" .) "key" "WORKSPACE_RUNNER_TOKEN")))
+  ) -}}
 {{- end -}}
 {{- if and $san (ne $san "") -}}
   {{- $_ := set $cfg "serviceAccountName" $san -}}

--- a/src/groundx/templates/_helpers/app/workspace.tpl
+++ b/src/groundx/templates/_helpers/app/workspace.tpl
@@ -14,6 +14,10 @@
     {{- if and (eq (dig "token" "" $in) "") (eq (dig "existingSecret" "" $in) "") -}}
       {{- fail "workspace requires workspace.token or workspace.existingSecret when enabled" -}}
     {{- end -}}
+    {{- $managedData := dig "managedData" dict $in -}}
+    {{- if and (dig "enabled" false $managedData) (eq (dig "existingSecret" "" $in) "") -}}
+      {{- fail "workspace managed data requires workspace.existingSecret" -}}
+    {{- end -}}
 true
   {{- else -}}false{{- end -}}
 {{- else -}}
@@ -181,6 +185,41 @@ false
 {{- define "groundx.workspace.managedRepoVisibility" -}}
 {{- $in := include "groundx.workspace.values" . | fromYaml -}}
 {{ dig "managedRepoVisibility" "private" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData" -}}
+{{- $in := include "groundx.workspace.values" . | fromYaml -}}
+{{ dig "managedData" dict $in | toYaml }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.enabled" -}}
+{{- $in := include "groundx.workspace.managedData" . | fromYaml -}}
+{{ dig "enabled" false $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.awsRegion" -}}
+{{- $in := include "groundx.workspace.managedData" . | fromYaml -}}
+{{ dig "awsRegion" "" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.environment" -}}
+{{- $managed := include "groundx.workspace.managedData" .root | fromYaml -}}
+{{ dig .environment dict $managed | toYaml }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.s3Bucket" -}}
+{{- $in := include "groundx.workspace.managedData.environment" . | fromYaml -}}
+{{ dig "s3Bucket" "" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.redisEndpoint" -}}
+{{- $in := include "groundx.workspace.managedData.environment" . | fromYaml -}}
+{{ dig "redisEndpoint" "" $in }}
+{{- end }}
+
+{{- define "groundx.workspace.managedData.redisUserGroup" -}}
+{{- $in := include "groundx.workspace.managedData.environment" . | fromYaml -}}
+{{ dig "redisUserGroup" "" $in }}
 {{- end }}
 
 {{- define "groundx.workspace.token" -}}

--- a/src/groundx/templates/resources/workspace-config-py.yaml
+++ b/src/groundx/templates/resources/workspace-config-py.yaml
@@ -37,6 +37,18 @@ data:
         managed_repo_name_prefix={{ include "groundx.workspace.managedRepoNamePrefix" . | quote }},
         managed_repo_owner={{ include "groundx.workspace.managedRepoOwner" . | quote }},
         managed_repo_visibility={{ include "groundx.workspace.managedRepoVisibility" . | quote }},
+{{- if eq (printf "%v" (include "groundx.workspace.managedData.enabled" .)) "true" }}
+        managed_data_enabled={{ if eq (printf "%v" (include "groundx.workspace.managedData.enabled" .)) "true" }}True{{ else }}False{{ end }},
+        managed_data_aws_region={{ include "groundx.workspace.managedData.awsRegion" . | quote }},
+        managed_data_rds_admin_connection_dev="",
+        managed_data_rds_admin_connection_prod="",
+        managed_data_s3_bucket_dev={{ include "groundx.workspace.managedData.s3Bucket" (dict "root" . "environment" "dev") | quote }},
+        managed_data_s3_bucket_prod={{ include "groundx.workspace.managedData.s3Bucket" (dict "root" . "environment" "prod") | quote }},
+        managed_data_redis_endpoint_dev={{ include "groundx.workspace.managedData.redisEndpoint" (dict "root" . "environment" "dev") | quote }},
+        managed_data_redis_endpoint_prod={{ include "groundx.workspace.managedData.redisEndpoint" (dict "root" . "environment" "prod") | quote }},
+        managed_data_redis_user_group_dev={{ include "groundx.workspace.managedData.redisUserGroup" (dict "root" . "environment" "dev") | quote }},
+        managed_data_redis_user_group_prod={{ include "groundx.workspace.managedData.redisUserGroup" (dict "root" . "environment" "prod") | quote }},
+{{- end }}
         mysql_connect_timeout_seconds={{ include "groundx.workspace.mysqlConnectTimeoutSeconds" . }},
         mysql_database={{ include "groundx.db.dbName" . | quote }},
         mysql_host={{ include "groundx.db.rw" . | quote }},

--- a/src/groundx/tests/files/values.workspace-managed-data.yaml
+++ b/src/groundx/tests/files/values.workspace-managed-data.yaml
@@ -1,0 +1,14 @@
+workspace:
+  enabled: true
+  existingSecret: workspace-managed-data
+  managedData:
+    enabled: true
+    awsRegion: us-east-1
+    dev:
+      s3Bucket: managed-dev
+      redisEndpoint: rediss://cache-dev.example:6379/0
+      redisUserGroup: managed-dev
+    prod:
+      s3Bucket: managed-prod
+      redisEndpoint: rediss://cache-prod.example:6379/0
+      redisUserGroup: managed-prod

--- a/src/groundx/tests/workspace_test.yaml
+++ b/src/groundx/tests/workspace_test.yaml
@@ -30,6 +30,25 @@ tests:
       - ./files/values.workspace.yaml
     asserts:
       - matchSnapshot: {}
+  - it: "enabled: workspace managed data"
+    templates:
+      - ../templates/resources/workspace-config-py.yaml
+    values:
+      - ./files/values.disabled.yaml
+      - ./files/values.workspace-managed-data.yaml
+    asserts:
+      - matchRegex:
+          path: 'data["config.py"]'
+          pattern: 'managed_data_enabled=True'
+      - matchRegex:
+          path: 'data["config.py"]'
+          pattern: 'managed_data_s3_bucket_dev="managed-dev"'
+      - matchRegex:
+          path: 'data["config.py"]'
+          pattern: 'managed_data_redis_user_group_prod="managed-prod"'
+      - notMatchRegex:
+          path: 'data["config.py"]'
+          pattern: 'rds_admin_connection_dev="mysql'
   - it: "disabled: workspace metrics config"
     templates:
       - ../templates/resources/config-yaml.yaml

--- a/src/groundx/tests/workspace_test.yaml
+++ b/src/groundx/tests/workspace_test.yaml
@@ -49,6 +49,28 @@ tests:
       - notMatchRegex:
           path: 'data["config.py"]'
           pattern: 'rds_admin_connection_dev="mysql'
+  - it: "groundx receives only the workspace runner token"
+    templates:
+      - ../templates/app/golang.yaml
+    values:
+      - ./files/values.workspace-managed-data.yaml
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: groundx
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WORKSPACE_RUNNER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: workspace-managed-data
+                key: WORKSPACE_RUNNER_TOKEN
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: workspace-managed-data
   - it: "disabled: workspace metrics config"
     templates:
       - ../templates/resources/config-yaml.yaml

--- a/src/groundx/values.schema.json
+++ b/src/groundx/values.schema.json
@@ -1481,6 +1481,33 @@
         "managedRepoNamePrefix": { "type": "string" },
         "managedRepoOwner": { "type": "string" },
         "managedRepoVisibility": { "type": "string" },
+        "managedData": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "awsRegion": { "type": "string" },
+            "dev": {
+              "type": "object",
+              "properties": {
+                "s3Bucket": { "type": "string" },
+                "redisEndpoint": { "type": "string" },
+                "redisUserGroup": { "type": "string" }
+              },
+              "additionalProperties": false
+            },
+            "prod": {
+              "type": "object",
+              "properties": {
+                "s3Bucket": { "type": "string" },
+                "redisEndpoint": { "type": "string" },
+                "redisUserGroup": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["enabled"],
+          "additionalProperties": false
+        },
         "mysqlConnectTimeoutSeconds": { "type": "integer" },
         "node": { "type": "string" },
         "publishGithubWorkflowId": { "type": "string" },

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -357,6 +357,20 @@ workspace:
   gitProvider: github
   publishGithubWorkflowId: deploy.yml
 
+  # Hosted AWS logical allocation. RDS administrator URLs must be supplied by
+  # existingSecret as MANAGED_DATA_RDS_ADMIN_CONNECTION_DEV and _PROD.
+  managedData:
+    enabled: false
+    awsRegion: ""
+    dev:
+      s3Bucket: ""
+      redisEndpoint: ""
+      redisUserGroup: ""
+    prod:
+      s3Bucket: ""
+      redisEndpoint: ""
+      redisUserGroup: ""
+
   github:
     apiBaseUrl: https://api.github.com
     appId: ""


### PR DESCRIPTION
Linear: AGE-344

## Summary

- Add disabled-by-default Workspace settings for managed project data.
- Pass non-secret AWS, S3, and Redis settings to every Workspace process.
- Keep RDS administrator URLs in the existing Kubernetes Secret.
- Preserve identical source and published Helm chart contracts.
- Document the dev-first rollout and least-privilege service identity.

## Validation

- `.build/bin/validate-helm.sh`
- 137 Helm tests and 813 snapshots passed.
- Chart lint, render, schema, mirror, and syntax checks passed.
- Strict OpenSpec validation passed.

## Deployment

This chart change creates no RDS, S3, Redis, IAM, or other cloud resources. Managed data remains disabled until operators provide the secret and service identity, then explicitly enable dev. Disabling it stops new reconciliation but does not delete existing app data.

## Companion Pull Requests

- https://github.com/EyeLevel-ai/groundx-workspace-runner/pull/9
- https://github.com/EyeLevel-ai/cashbot-go/pull/1703
- https://github.com/GroundX-Studio/groundx-web-ui-scaffold/pull/13
- https://github.com/EyeLevel-ai/groundx-studio-harness/pull/204