### PR TITLE
test(resources): assert config.yaml on stringData not data (GX-17 Secret straggler)

### DIFF
--- a/src/groundx/tests/resources_test.yaml
+++ b/src/groundx/tests/resources_test.yaml
@@ -14,7 +14,7 @@ tests:
       value: config-yaml-map
     asserts:
       - notMatchRegex:
-          path: data["config.yaml"]
+          path: stringData["config.yaml"]
           pattern: "extractionCaptureAccounts"
   - it: "configured extraction capture accounts render exactly"
     templates:
@@ -27,7 +27,7 @@ tests:
       value: config-yaml-map
     asserts:
       - matchRegex:
-          path: data["config.yaml"]
+          path: stringData["config.yaml"]
           pattern: "integrationTests:\\n  extractionCaptureAccounts:\\n\\n    - internal-certification-account\\n    - second-internal-account\\n  search:"
   - it: "default: resources"
     templates:


### PR DESCRIPTION
Fixes a pre-existing red in the `0.2.7` helm gate, unrelated to any feature.

`config-yaml` renders as `kind: Secret` (`stringData`) since GX-17 (PR #78), but two assertions in `src/groundx/tests/resources_test.yaml` still referenced the old ConfigMap `data["config.yaml"]` path, so `helm unittest` (and thus `.build/bin/validate-helm.sh`, the push/CI gate) failed on `configured extraction capture accounts render exactly` with `unknown path data["config.yaml"]`.

Change: two lines, `data["config.yaml"]` to `stringData["config.yaml"]`, matching the Secret the template already renders. No template change; `tests/` is not part of the published chart.

Verified: full `.build/bin/validate-helm.sh` passes (was red on this test before). Confirmed the failure reproduced on a clean `origin/0.2.7` (156aecc), so it is pre-existing, not introduced here.

Prereq for the GX-25 push: `groundx-on-prem`'s `pre-push` gate cannot pass until this merges into `0.2.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)