### PR TITLE
Fix extract worker shutdown signal delivery

### DIFF
--- a/helm/templates/app/celery.yaml
+++ b/helm/templates/app/celery.yaml
@@ -145,7 +145,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+              export PYTHONPATH=/app &&{{ if eq $mapPrefix "extract" }} exec{{ end }} supervisord -c /app/supervisord.conf
 {{- if gt (len $lifecycle) 0 }}
           lifecycle:
 {{- toYaml $lifecycle | nindent 12 }}

--- a/src/groundx/templates/app/celery.yaml
+++ b/src/groundx/templates/app/celery.yaml
@@ -145,7 +145,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+              export PYTHONPATH=/app &&{{ if eq $mapPrefix "extract" }} exec{{ end }} supervisord -c /app/supervisord.conf
 {{- if gt (len $lifecycle) 0 }}
           lifecycle:
 {{- toYaml $lifecycle | nindent 12 }}

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -689,7 +689,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -853,7 +853,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -999,7 +999,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -3710,7 +3710,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -3875,7 +3875,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -4022,7 +4022,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -4830,7 +4830,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -4994,7 +4994,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -5140,7 +5140,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -5927,7 +5927,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -6092,7 +6092,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -6239,7 +6239,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -8886,7 +8886,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -9046,7 +9046,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:
@@ -9188,7 +9188,7 @@
                 - /bin/sh
                 - -c
                 - |
-                  export PYTHONPATH=/app && supervisord -c /app/supervisord.conf
+                  export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf
               env:
                 - name: POD_NAME
                   valueFrom:

--- a/src/groundx/tests/celery_test.yaml
+++ b/src/groundx/tests/celery_test.yaml
@@ -152,3 +152,27 @@ tests:
             name: credentials-volume
             secret:
               secretName: layout-ocr-credentials-map
+  - it: "extract workers replace the shell with supervisord"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values/extract/values.yaml
+    documentSelector:
+      path: metadata.name
+      value: extract-download
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[2]
+          value: "export PYTHONPATH=/app && exec supervisord -c /app/supervisord.conf\n"
+  - it: "non-extract workers keep their existing startup command"
+    templates:
+      - ../templates/app/celery.yaml
+    values:
+      - ../values.yaml
+    documentSelector:
+      path: metadata.name
+      value: layout-correct
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[2]
+          value: "export PYTHONPATH=/app && supervisord -c /app/supervisord.conf\n"

--- a/src/groundx/tests/resources_test.yaml
+++ b/src/groundx/tests/resources_test.yaml
@@ -14,7 +14,7 @@ tests:
       value: config-yaml-map
     asserts:
       - notMatchRegex:
-          path: data["config.yaml"]
+          path: stringData["config.yaml"]
           pattern: "extractionCaptureAccounts"
   - it: "configured extraction capture accounts render exactly"
     templates:
@@ -27,7 +27,7 @@ tests:
       value: config-yaml-map
     asserts:
       - matchRegex:
-          path: data["config.yaml"]
+          path: stringData["config.yaml"]
           pattern: "integrationTests:\\n  extractionCaptureAccounts:\\n\\n    - internal-certification-account\\n    - second-internal-account\\n  search:"
   - it: "default: resources"
     templates:


### PR DESCRIPTION
## Problem

Extraction workers run a shell as PID 1, with supervisord and Celery behind it. Kubernetes sends SIGTERM to the shell during deployments and node scale-down. The shell does not forward it, so a terminating worker can keep reserving tasks until forced removal.

This caused extract-download task 83d6b409-de42-4d48-878d-41470a79470a to be accepted after its pod entered termination, then lost when the node was removed.

## Change

- Use exec when launching supervisord for extract-agent, extract-download, and extract-save, making supervisord PID 1.
- Leave every non-extract Celery command unchanged.
- Keep existing lifecycle hooks and Celery acknowledgement, retry, visibility, and redelivery behavior unchanged.
- Repair two stale ConfigMap-to-Secret test paths already failing on the base branch.

## Verification

- Added explicit assertions for extraction and non-extraction startup commands.
- Updated extraction snapshots only.
- Ran .build/bin/validate-helm.sh: 208 tests and 815 snapshots passed, including lint, both chart surfaces, render checks, mirror checks, and contract checks.

## Rollout

Deploy this chart change first. Verify supervisord is PID 1 and a terminating extraction worker stops reserving new tasks while completing active work. Then set max-graceful-termination-sec=900 on the separately managed eyelevel-ca release and validate an actual node scale-down. The autoscaler release is not tracked in this repository.