### PR TITLE
docs: record Anthropic production validation and cleanup

### DIFF
--- a/openspec/changes/add-anthropic-workflow-engine-service/image-payload-default.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/image-payload-default.md
@@ -1,0 +1,14 @@
+# Hosted extraction image payload default
+
+Remove `extract.agent.maxImagePayloadBytes: 10485760` from both local operator values files and the current hosted Helm configuration. Use the existing chart default of 41943040 bytes. Do not change chart templates, container images, model settings, other release values or historical evidence.
+
+## Execution
+
+- [x] Verify account 903713046261, context gxprod, namespace eyelevel and current deployed release.
+- [x] Remove the override from `values.ranker-only-eks.yaml` and `values.ranker-only-eks.original.yaml`. These operator files remain ignored because they contain deployment credentials.
+- [x] Render the deployed chart with only that override removed; the only manifest change is the extract-agent environment value from 10485760 to 41943040. The stored chart values also contained 10485760; restore that single default to the pushed chart's 41943040. Other defaults and templates are unchanged.
+- [x] Upgrade release 351 to 352, wait for rollout and old workers to exit, and verify live environment and image identity. The production `configured_max_image_payload_bytes()` function returns 41943040. All other 58 resources are unchanged.
+- [x] Rerun the unchanged ADP Haiku canary. It completed with all seven reconciliation and QA groups passing, without the image-limit failure. Raw final output scored 85/102 (83.33%). Provider validation passed; accuracy is informational and no other documents were submitted. Evaluation evidence and all 17 scorer differences are recorded under the ADP evaluation plan.
+- [x] Remove temporary secret-bearing deployment snapshots after verification. Retain redacted proof and evaluation evidence. Helm revision 351 remains available for rollback.
+
+Private deployment work belongs in `/Users/benjaminfletcher/git/groundx-on-prem/openspec/work/add-anthropic-workflow-engine-service/image-payload-default-20260908`. Retention review is due 2026-09-15, not automatic deletion authorization. The existing ADP evaluation plan owns its separate retry artifacts. The increased image allowance may increase non-Bedrock agent memory use. Historical Helm revisions retain the prior override for rollback and are not configuration sources for new deployments.

--- a/openspec/changes/add-anthropic-workflow-engine-service/provider-closeout.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/provider-closeout.md
@@ -1,0 +1,19 @@
+# Anthropic provider validation
+
+Native Anthropic completed production text and image canaries, followed by the full ADP V4 canary on Haiku 4.5. The ADP run completed 476 page-extraction calls, seven reconciliation groups, seven QA groups, final save and raw readback. Provider validation passed. Its 85/102 field score is informational; further accuracy testing is outside this closeout.
+
+Helm revision 352 uses the existing 41,943,040-byte image-payload default. The 10 MiB override was removed from both ignored operator values files and the live release. The extract-agent environment was the only changed manifest value; 58 other resources and all images were unchanged. `image-payload-default.md` and `source-text-release.md` record deployment provenance and rollback.
+
+## Cleanup
+
+- Deleted isolated synthetic buckets 33447 and 33448 and workflows `a8500c47-5388-4ef5-9645-d0073fd07200` and `478ae621-c59b-484f-8ab6-c8871a3e19bc`.
+- The ADP closeout also deleted buckets 33471 and 33472 and their model-specific workflows. All four buckets contained exactly ten canary documents/retries, with no workflow assigned elsewhere. DELETE returned 200; subsequent bucket/workflow GETs returned 400, confirming absence.
+- Retained successful text/image boundary fixtures at `openspec/work/add-anthropic-workflow-engine-service/prod-20260908/source-text-retest/`. All 145 text and 146 image trace objects pass their saved hashes. Existing small deployment evidence remains in the parent runtime root and `image-payload-default-20260908/`.
+- Evidence owner: release coordinator. Retention review: 2026-09-15, not automatic deletion authorization. Local evidence is ignored and not committed. Hosted bucket deletion is irreversible; direct storage-object deletion was not performed.
+- Removed the clean, fully contained `AGE-336-deploy` and `age336-page-window-limit` worktrees, the obsolete `fix/age336-page-window-limit` local branch, and a stale worktree registration. Merged Anthropic PR remote branches were already absent. Active PR branches and unrelated work remain untouched.
+
+## Remaining release scope
+
+This closes provider validation, not general chart-release certification. Task 4.4 remains open: inventory other opted-in deployments and document any existing custom-engine `service`/`serviceType` precedence impact before their chart rollout. No further ADP accuracy run is required for provider validation.
+
+The full `.build/bin/validate-helm.sh` gate passes on the closeout branch. No chart template, source/mirror pair, image, credential or production default-provider setting changes in this PR. The two credential-bearing operator values files remain ignored.

--- a/openspec/changes/add-anthropic-workflow-engine-service/release-verification.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/release-verification.md
@@ -1,11 +1,11 @@
 # Anthropic release verification
 
-Status as of 2026-09-08 UTC: production `PreProcessTrainFile` now runs Cashbot
-`d8c8e69`. Both synthetic workflow dispatches preserve Anthropic and include the
-required metadata. The image document completes through QA and final retrieval.
-The TXT document reaches QA but fails because it has no derived page images.
-Kubernetes remains at restored Helm revision 350. No customer defaults or
-credentials were changed.
+Status as of 2026-09-08 12:20 UTC: the merged metadata guard and source-text fixes
+are deployed. Both synthetic text and image workflows pass through QA, callback,
+and authoritative final retrieval. See [source-text-release.md](source-text-release.md)
+for current images, resource IDs, and boundary evidence. The sections below retain
+the earlier deployment and failed-canary history. No customer defaults or credentials
+were changed.
 
 ## Source prerequisites
 
@@ -20,7 +20,7 @@ credentials were changed.
 Internal Arcadia's current main passed its container-import smoke and Python test
 matrix in [CI run 34175126227](https://github.com/eyelevelai/internal-arcadia-agents/actions/runs/34175126227).
 
-## Current runtime inventory
+## Runtime inventory before the source-text release
 
 - Both hosted summary servers expose healthy endpoints. Their running binaries embed
   clean commit `589d4c9fddbf2b0bb066b8cdf6bab9e80822887f`, which contains the Cashbot

--- a/openspec/changes/add-anthropic-workflow-engine-service/source-text-release.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/source-text-release.md
@@ -1,0 +1,74 @@
+# Metadata guard and source-text production release
+
+Both isolated synthetic workflows passed on 2026-09-08. The TXT workflow previously
+failed during QA because it had no derived images. QA now receives its original source
+text. The image workflow continues to use its page image. Customer defaults, credentials,
+source files, and workflow definitions remain unchanged.
+
+## Deployment
+
+Target: AWS account `903713046261`, `us-west-2`; Kubernetes context `gxprod`, namespace
+`eyelevel`, Helm release `groundx`, revision `351`.
+
+| Component | Source | GitHub Actions build | Immutable image |
+| --- | --- | --- | --- |
+| PreProcessTrainFile | `2137e1a2603abeb405a7c52223cdaf8806729749` | [34224245271](https://github.com/EyeLevel-ai/cashbot-go/actions/runs/34224245271) | `903713046261.dkr.ecr.us-west-2.amazonaws.com/pre-process-lambda@sha256:4b9453beb8b0173da48fee1c7f6c75bef6fe6801095db52261f4c6602cc1d138` |
+| Extract API, download, agent, save | `a9fef08328fa0809e8785aa28dbe3b7988663c5a` | [34224248758](https://github.com/eyelevelai/internal-arcadia-agents/actions/runs/34224248758) | `public.ecr.aws/c9r4x6y5/eyelevel/extract@sha256:6f056226fa48286572f68cada2336235591bc195712ce238a304afb87434686d` |
+
+Both builds passed, including both extraction architectures and their manifest. Lambda
+is Active with a Successful update; runtime configuration and SQS mapping are unchanged.
+The mapping remains enabled with `ReportBatchItemFailures`.
+
+The image-only Helm rollout used the existing release chart and configuration. Its actual
+manifest matches the server dry run: four Deployment image replacements and 55 unchanged
+resources. All four workloads are ready and report the source SHA in `/app/BUILD_COMMIT`.
+Old pods exited before canary submission. Worker grace periods remain 900 seconds.
+
+Rollback: use the Cashbot release script with the previous Lambda image
+`903713046261.dkr.ecr.us-west-2.amazonaws.com/pre-process-lambda@sha256:2866bb3de85807d22f81a57a5f34366b13ec26193fcb19b5f8faf8f1ca5d21b9`.
+For extraction, `helm --kube-context gxprod rollback groundx 350 -n eyelevel --wait
+--timeout 20m` restores the previous image and configuration.
+
+## Canary results
+
+Both saved workflows still select native Anthropic `claude-sonnet-4-6` with
+`maxImages: 5`. This test does not use Bedrock or S3 image transport.
+
+| Case | Bucket | Workflow | Process | Document |
+| --- | --- | --- | --- | --- |
+| Text | 33447 | `a8500c47-5388-4ef5-9645-d0073fd07200` | `bc0d4082-620b-4bac-b0e3-7b0eb1d27a01` | `45b8c2fb-7e26-408e-b8be-474248ea3628` |
+| Image | 33448 | `478ae621-c59b-484f-8ab6-c8871a3e19bc` | `3124d141-d99e-449d-9c5c-3ef28d4d52ea` | `4a9f51cc-ecbd-4b70-97ec-88f556ee018e` |
+
+- Text final output: `{"account":{"delivery_summary":"Delivery report reference code CANARY-742: The delivery arrived on time and was accepted."}}`.
+- Image final output: `{"account":{"account_code":"CHECK-93B71F"}}`.
+- Both API-ingress packets include `extraction_workflow_metadata_v1`.
+- Both reconciliation stages pass the no-conflict path without a provider call.
+- Text QA receives all original text and zero images. Its Anthropic response is
+  `msg_011CeqxLPMRwRQxrBDUL9YiM`.
+- Image QA receives one image and no text-fallback section. Its Anthropic response is
+  `msg_011CeqxMkBqm361c7AQMx3FT`.
+- Private `_source_text` survives the QA handoff but is absent from terminal save and
+  final customer JSON. Both callbacks persist successfully; `get_extract` matches.
+
+## Evidence and limits
+
+Private evidence remains under
+`openspec/work/add-anthropic-workflow-engine-service/prod-20260908/source-text-retest/`.
+It contains raw final outputs, X-Rays, unchanged workflow readbacks, stage inputs and
+outputs, model requests and responses, callback evidence, and deployment verification.
+All 145 text and 146 image trace objects pass their saved SHA-256 checks. Stage records
+report complete capture with no missing artifacts. Earlier runs remain unchanged.
+
+| Artifact | SHA-256 |
+| --- | --- |
+| Text final JSON | `6f03c61318461b31699166f3b71a32434135a1bf299f0c3e914c0e30bdbb6ac3` |
+| Image final JSON | `1e48e36cc4e9a30fef0f12cbae0007ff8de1451e537a57c356a19ac6e0cbcaeb` |
+
+These canaries prove image-free statement QA and unchanged image-backed statement QA.
+They do not prove live conflict reconciliation, meter or charge model calls, deliberate
+missing-metadata rejection, or a complete on-prem chart release. Those are not outcomes
+of the two synthetic workflows. The broader chart rollout task remains open.
+
+Retain the isolated resources and private boundary evidence pending cleanup approval.
+The existing evidence retention date is 2026-09-15. Temporary secret-bearing Helm
+snapshots are not durable evidence; Helm retains the rollback revision.

--- a/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
+++ b/openspec/changes/add-anthropic-workflow-engine-service/tasks.md
@@ -87,6 +87,30 @@
 
 ### Production canary
 
+### Merged metadata guard and source-text release
+
+- [x] Build Cashbot `2137e1a2603abeb405a7c52223cdaf8806729749` preprocessing Lambda
+  and Arcadia `a9fef08328fa0809e8785aa28dbe3b7988663c5a` extract image through
+  their owning GitHub Actions workflows. Verify both build source SHAs and digests.
+- [x] Snapshot the production Lambda, SQS mapping, Helm revision, and four extract
+  workloads. Deploy only those images in account `903713046261`, `us-west-2`,
+  context `gxprod`, namespace `eyelevel`. Preserve the existing chart, configuration,
+  credentials, and customer workflows. Verify the rendered changes contain only the
+  four extraction image replacements. Preserve worker graceful termination.
+- [x] Verify runtime identity and readiness. Restore the prior Lambda image through
+  the release script and Helm revision 350 if deployment verification fails.
+- [x] Resubmit the existing synthetic text and image sources to buckets 33447 and
+  33448 with unchanged workflows. Save new evidence in `source-text-retest/` under
+  the existing private runtime root. Verify metadata, original text in image-free QA,
+  unchanged image evidence, final callback, and authoritative `get_extract` output.
+  Distinguish no-conflict reconciliation from a reconciliation provider call.
+- [x] Record build/deployment provenance and canary results. Retain prior evidence
+  and isolated resources pending cleanup approval. No chart release or customer
+  default provider assignment is included.
+  Both canaries pass. Current deployment and evidence are recorded in
+  `source-text-release.md`. Reconciliation used the no-conflict path; QA made one
+  Anthropic call per document, using original text for TXT and one image for PNG.
+
 ### Dispatch Lambda compatibility and retest
 
 - [x] Identify the failed boundary. Production `PreProcessTrainFile` source


### PR DESCRIPTION
## Summary

Record the deployed metadata guard and source-text fixes, successful text/image canaries, and the ADP Haiku provider pass. Document Helm revision 352 restoring the existing 40 MiB image-payload default without image or other manifest changes.

Record deletion of four isolated test buckets/workflows, retention of successful boundary evidence, and removal of obsolete worktrees. General chart rollout task 4.4 remains open for other deployment inventories. ADP accuracy is not a provider acceptance gate.

This PR changes documentation only. Credential-bearing operator values and private runtime evidence remain ignored.

## Validation

- Full .build/bin/validate-helm.sh gate passed.
- Strict OpenSpec validation and diff whitespace checks passed.
- Successful boundary hashes verified before resource deletion.
- No credentials found in the changed files.