### PR TITLE
docs(kafka-cluster): GX-25 runbook — explicit operator upgrade, warn against --reuse-values

### DIFF
--- a/helm/prereqs/kafka-cluster/README.md
+++ b/helm/prereqs/kafka-cluster/README.md
@@ -74,6 +74,23 @@ Then run the ordered procedure:
    Kafka `4.0.0` (the version an operator-`0.47.0`-era 0.1.x install runs), so upgrading straight to
    it would reject such a cluster. Do not upgrade straight to a `v1`-only operator release from a
    `v1beta2`-only one.
+
+   Run the upgrade with an **explicit** command and do not use `helm upgrade --reuse-values`. `0.50.1`
+   adds a new `operatorNetworkPolicy` value the older operator chart lacks, so `--reuse-values` keeps
+   the old chart's defaults, fails at render (`nil pointer evaluating interface {}.enabled` on
+   `operatorNetworkPolicy.enabled`), and applies nothing. It is safe (nothing changes) but the
+   operator never upgrades. Re-supply the values instead, reusing the existing operator release name:
+
+   ```bash
+   helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+     --version 0.50.1 -n <namespace> \
+     --set replicas=1 --set nodeSelector.node=eyelevel-cpu-only \
+     --wait
+   ```
+
+   To carry other custom operator values without re-listing them, use `--reset-then-reuse-values`
+   (which picks up the new chart's defaults, including `operatorNetworkPolicy`) rather than
+   `--reuse-values`.
 2. **Apply the new Strimzi CRDs.** `helm upgrade` of the operator does **not** upgrade CRDs, so
    after step 1 the cluster's Strimzi CRDs still serve only `v1beta2`. Apply the operator release's
    CRD bundle so every Strimzi CRD serves both `v1beta2` and `v1`

--- a/helm/prereqs/kafka-cluster/README.md
+++ b/helm/prereqs/kafka-cluster/README.md
@@ -88,13 +88,23 @@ Then run the ordered procedure:
      --wait
    ```
 
-   To carry other custom operator values without re-listing them, export them and re-apply them on
-   the upgrade (works on the supported Helm `3.8+`): run `helm get values <operator-release> -n
-   <namespace> -o yaml > operator-values.yaml`, then add `-f operator-values.yaml` to the
-   `helm upgrade` above. That re-supplies only your overrides against the new chart, so new keys like
-   `operatorNetworkPolicy` still take the new chart's default. On Helm `3.14+` you can instead pass
-   `--reset-then-reuse-values` as a shorthand. Do not use `--reuse-values` (it keeps the old chart's
-   defaults and fails on `0.50.1`).
+   To carry other custom operator values without re-listing them: on Helm `3.14+`, pass
+   `--reset-then-reuse-values` (credential-safe, nothing written to disk; it picks up the new chart's
+   defaults, including `operatorNetworkPolicy`). On the supported older clients (Helm `3.8`-`3.13`),
+   export and re-apply your values through a private temporary file and delete it afterward, because
+   the export can contain secrets (for example a token in `extraEnvs`):
+
+   ```bash
+   umask 077; f=$(mktemp)
+   helm get values <operator-release> -n <namespace> -o yaml > "$f"
+   helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+     --version 0.50.1 -n <namespace> -f "$f" --wait
+   rm -f "$f"
+   ```
+
+   Re-applying your overrides this way still lets new keys like `operatorNetworkPolicy` take the new
+   chart's default. Do not use `--reuse-values` (it keeps the old chart's defaults and fails on
+   `0.50.1`).
 2. **Apply the new Strimzi CRDs.** `helm upgrade` of the operator does **not** upgrade CRDs, so
    after step 1 the cluster's Strimzi CRDs still serve only `v1beta2`. Apply the operator release's
    CRD bundle so every Strimzi CRD serves both `v1beta2` and `v1`

--- a/helm/prereqs/kafka-cluster/README.md
+++ b/helm/prereqs/kafka-cluster/README.md
@@ -88,9 +88,13 @@ Then run the ordered procedure:
      --wait
    ```
 
-   To carry other custom operator values without re-listing them, use `--reset-then-reuse-values`
-   (which picks up the new chart's defaults, including `operatorNetworkPolicy`) rather than
-   `--reuse-values`.
+   To carry other custom operator values without re-listing them, export them and re-apply them on
+   the upgrade (works on the supported Helm `3.8+`): run `helm get values <operator-release> -n
+   <namespace> -o yaml > operator-values.yaml`, then add `-f operator-values.yaml` to the
+   `helm upgrade` above. That re-supplies only your overrides against the new chart, so new keys like
+   `operatorNetworkPolicy` still take the new chart's default. On Helm `3.14+` you can instead pass
+   `--reset-then-reuse-values` as a shorthand. Do not use `--reuse-values` (it keeps the old chart's
+   defaults and fails on `0.50.1`).
 2. **Apply the new Strimzi CRDs.** `helm upgrade` of the operator does **not** upgrade CRDs, so
    after step 1 the cluster's Strimzi CRDs still serve only `v1beta2`. Apply the operator release's
    CRD bundle so every Strimzi CRD serves both `v1beta2` and `v1`

--- a/helm/prereqs/kafka-cluster/README.md
+++ b/helm/prereqs/kafka-cluster/README.md
@@ -95,12 +95,17 @@ Then run the ordered procedure:
    the export can contain secrets (for example a token in `extraEnvs`):
 
    ```bash
-   umask 077; f=$(mktemp)
-   helm get values <operator-release> -n <namespace> -o yaml > "$f"
-   helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-     --version 0.50.1 -n <namespace> -f "$f" --wait
-   rm -f "$f"
+   (
+     umask 077
+     f=$(mktemp)
+     trap 'rm -f "$f"' EXIT INT TERM
+     helm get values <operator-release> -n <namespace> -o yaml > "$f"
+     helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+       --version 0.50.1 -n <namespace> -f "$f" --wait
+   )
    ```
+   The subshell keeps `umask` out of your shell session, and the `trap` deletes the values file on
+   success, on a failed command, or on interrupt.
 
    Re-applying your overrides this way still lets new keys like `operatorNetworkPolicy` take the new
    chart's default. Do not use `--reuse-values` (it keeps the old chart's defaults and fails on

--- a/src/groundx/prereqs/kafka-cluster/README.md
+++ b/src/groundx/prereqs/kafka-cluster/README.md
@@ -74,6 +74,23 @@ Then run the ordered procedure:
    Kafka `4.0.0` (the version an operator-`0.47.0`-era 0.1.x install runs), so upgrading straight to
    it would reject such a cluster. Do not upgrade straight to a `v1`-only operator release from a
    `v1beta2`-only one.
+
+   Run the upgrade with an **explicit** command and do not use `helm upgrade --reuse-values`. `0.50.1`
+   adds a new `operatorNetworkPolicy` value the older operator chart lacks, so `--reuse-values` keeps
+   the old chart's defaults, fails at render (`nil pointer evaluating interface {}.enabled` on
+   `operatorNetworkPolicy.enabled`), and applies nothing. It is safe (nothing changes) but the
+   operator never upgrades. Re-supply the values instead, reusing the existing operator release name:
+
+   ```bash
+   helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+     --version 0.50.1 -n <namespace> \
+     --set replicas=1 --set nodeSelector.node=eyelevel-cpu-only \
+     --wait
+   ```
+
+   To carry other custom operator values without re-listing them, use `--reset-then-reuse-values`
+   (which picks up the new chart's defaults, including `operatorNetworkPolicy`) rather than
+   `--reuse-values`.
 2. **Apply the new Strimzi CRDs.** `helm upgrade` of the operator does **not** upgrade CRDs, so
    after step 1 the cluster's Strimzi CRDs still serve only `v1beta2`. Apply the operator release's
    CRD bundle so every Strimzi CRD serves both `v1beta2` and `v1`

--- a/src/groundx/prereqs/kafka-cluster/README.md
+++ b/src/groundx/prereqs/kafka-cluster/README.md
@@ -88,13 +88,23 @@ Then run the ordered procedure:
      --wait
    ```
 
-   To carry other custom operator values without re-listing them, export them and re-apply them on
-   the upgrade (works on the supported Helm `3.8+`): run `helm get values <operator-release> -n
-   <namespace> -o yaml > operator-values.yaml`, then add `-f operator-values.yaml` to the
-   `helm upgrade` above. That re-supplies only your overrides against the new chart, so new keys like
-   `operatorNetworkPolicy` still take the new chart's default. On Helm `3.14+` you can instead pass
-   `--reset-then-reuse-values` as a shorthand. Do not use `--reuse-values` (it keeps the old chart's
-   defaults and fails on `0.50.1`).
+   To carry other custom operator values without re-listing them: on Helm `3.14+`, pass
+   `--reset-then-reuse-values` (credential-safe, nothing written to disk; it picks up the new chart's
+   defaults, including `operatorNetworkPolicy`). On the supported older clients (Helm `3.8`-`3.13`),
+   export and re-apply your values through a private temporary file and delete it afterward, because
+   the export can contain secrets (for example a token in `extraEnvs`):
+
+   ```bash
+   umask 077; f=$(mktemp)
+   helm get values <operator-release> -n <namespace> -o yaml > "$f"
+   helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+     --version 0.50.1 -n <namespace> -f "$f" --wait
+   rm -f "$f"
+   ```
+
+   Re-applying your overrides this way still lets new keys like `operatorNetworkPolicy` take the new
+   chart's default. Do not use `--reuse-values` (it keeps the old chart's defaults and fails on
+   `0.50.1`).
 2. **Apply the new Strimzi CRDs.** `helm upgrade` of the operator does **not** upgrade CRDs, so
    after step 1 the cluster's Strimzi CRDs still serve only `v1beta2`. Apply the operator release's
    CRD bundle so every Strimzi CRD serves both `v1beta2` and `v1`

--- a/src/groundx/prereqs/kafka-cluster/README.md
+++ b/src/groundx/prereqs/kafka-cluster/README.md
@@ -88,9 +88,13 @@ Then run the ordered procedure:
      --wait
    ```
 
-   To carry other custom operator values without re-listing them, use `--reset-then-reuse-values`
-   (which picks up the new chart's defaults, including `operatorNetworkPolicy`) rather than
-   `--reuse-values`.
+   To carry other custom operator values without re-listing them, export them and re-apply them on
+   the upgrade (works on the supported Helm `3.8+`): run `helm get values <operator-release> -n
+   <namespace> -o yaml > operator-values.yaml`, then add `-f operator-values.yaml` to the
+   `helm upgrade` above. That re-supplies only your overrides against the new chart, so new keys like
+   `operatorNetworkPolicy` still take the new chart's default. On Helm `3.14+` you can instead pass
+   `--reset-then-reuse-values` as a shorthand. Do not use `--reuse-values` (it keeps the old chart's
+   defaults and fails on `0.50.1`).
 2. **Apply the new Strimzi CRDs.** `helm upgrade` of the operator does **not** upgrade CRDs, so
    after step 1 the cluster's Strimzi CRDs still serve only `v1beta2`. Apply the operator release's
    CRD bundle so every Strimzi CRD serves both `v1beta2` and `v1`

--- a/src/groundx/prereqs/kafka-cluster/README.md
+++ b/src/groundx/prereqs/kafka-cluster/README.md
@@ -95,12 +95,17 @@ Then run the ordered procedure:
    the export can contain secrets (for example a token in `extraEnvs`):
 
    ```bash
-   umask 077; f=$(mktemp)
-   helm get values <operator-release> -n <namespace> -o yaml > "$f"
-   helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-     --version 0.50.1 -n <namespace> -f "$f" --wait
-   rm -f "$f"
+   (
+     umask 077
+     f=$(mktemp)
+     trap 'rm -f "$f"' EXIT INT TERM
+     helm get values <operator-release> -n <namespace> -o yaml > "$f"
+     helm upgrade <operator-release> oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+       --version 0.50.1 -n <namespace> -f "$f" --wait
+   )
    ```
+   The subshell keeps `umask` out of your shell session, and the `trap` deletes the values file on
+   success, on a failed command, or on interrupt.
 
    Re-applying your overrides this way still lets new keys like `operatorNetworkPolicy` take the new
    chart's default. Do not use `--reuse-values` (it keeps the old chart's defaults and fails on


### PR DESCRIPTION
Follow-up to #87 (GX-25). The migration runbook's step 1 said "upgrade the Strimzi operator in place to 0.50.1" without naming the command. "In place, keep my values" leads a reader to `helm upgrade --reuse-values`, which fails on 0.50.1:

```
Error: UPGRADE FAILED: strimzi-kafka-operator/templates/052-NetworkPolicy-strimzi-cluster-operator.yaml:1:14
  executing ... at <.Values.operatorNetworkPolicy.enabled>: nil pointer evaluating interface {}.enabled
```

Cause: `--reuse-values` keeps the old chart's defaults, so `operatorNetworkPolicy` (new in 0.50.1) is absent. It fails at render, applies nothing (safe), but the operator never upgrades.

Fix: step 1 now gives the explicit re-supply-values command and points at `--reset-then-reuse-values` (not `--reuse-values`) for custom values. Edited both `src/groundx/prereqs/kafka-cluster/README.md` and its byte-identical `helm/` mirror.

The `strimzi-migration-kind` CI leg upgrades the operator with explicit `--set`, never `--reuse-values`, so it stays green and cannot catch this. This is a doc-precision fix; no code or CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfRcFM37F8HSLjDoHJL4wY