### PR TITLE
Default extraction download concurrency to one

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -457,6 +457,7 @@ extract:
 
   download:
     enabled: false
+    threads: 1
 
     replicas:
       desired: 1

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -666,7 +666,7 @@
         metadata:
           annotations:
             config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -827,7 +827,7 @@
         metadata:
           annotations:
             config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -970,7 +970,7 @@
         metadata:
           annotations:
             config-hash: fee66106f5e1140dc1362d0d602dcaa285dc96d1d656da9bd9caa21eaf197f87
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -3678,7 +3678,7 @@
         metadata:
           annotations:
             config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -3840,7 +3840,7 @@
         metadata:
           annotations:
             config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -3984,7 +3984,7 @@
         metadata:
           annotations:
             config-hash: d72d210a23c67cfabc982558327e5a1c5d313e2231220a0330e1cebec6ba7a4b
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -4789,7 +4789,7 @@
         metadata:
           annotations:
             config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -4950,7 +4950,7 @@
         metadata:
           annotations:
             config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -5093,7 +5093,7 @@
         metadata:
           annotations:
             config-hash: 00dd76424f0d58456a83c47a71aaf19e7d3362691a1f902bcb7091772b6e82a7
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -5877,7 +5877,7 @@
         metadata:
           annotations:
             config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -6039,7 +6039,7 @@
         metadata:
           annotations:
             config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -6183,7 +6183,7 @@
         metadata:
           annotations:
             config-hash: cf265528b5a8552aeae0bd6dc7db4bed7506f6e22f7cd148d584cccd1b09bc56
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -8827,7 +8827,7 @@
         metadata:
           annotations:
             config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -8984,7 +8984,7 @@
         metadata:
           annotations:
             config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -9123,7 +9123,7 @@
         metadata:
           annotations:
             config-hash: e33d1c49768c465e79e5e28a088291b561515cde84cefa29100814485bd30a1c
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:

--- a/src/groundx/tests/__snapshot__/golang_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/golang_test.yaml.snap
@@ -794,7 +794,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: groundx
         spec:
@@ -940,7 +940,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: layout-webhook
         spec:
@@ -1058,7 +1058,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: pre-process
         spec:
@@ -1160,7 +1160,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: process
         spec:
@@ -1262,7 +1262,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: queue
         spec:
@@ -1364,7 +1364,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: summary-client
         spec:
@@ -1466,7 +1466,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d5a1b077cd8e7462c27d29d016be44ccf342cc948917da07fa0754761efc1ec4
+            config-hash: 1faad32a6e3d26082d2428a7d24b579250eacbbbe98abf124dbc3b748747c687
           labels:
             app: upload
         spec:
@@ -3895,7 +3895,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: groundx
         spec:
@@ -4031,7 +4031,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: layout-webhook
         spec:
@@ -4153,7 +4153,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: pre-process
         spec:
@@ -4259,7 +4259,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: process
         spec:
@@ -4365,7 +4365,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: queue
         spec:
@@ -4471,7 +4471,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: summary-client
         spec:
@@ -4577,7 +4577,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 75511657d9c9f7d70816f937d53e22f1366dce22d3e5eb3a4a742f93d3748501
+            config-hash: cc01b542e3094cc3f9123ff87827020fa8b1250c20502f9426929f13f4be80ee
           labels:
             app: upload
         spec:
@@ -4684,7 +4684,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: groundx
         spec:
@@ -4816,7 +4816,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: layout-webhook
         spec:
@@ -4934,7 +4934,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: pre-process
         spec:
@@ -5036,7 +5036,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: process
         spec:
@@ -5138,7 +5138,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: queue
         spec:
@@ -5240,7 +5240,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: summary-client
         spec:
@@ -5342,7 +5342,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c51dec83ab3e7f09721c34b8755389c201876037226aeeafc40cddc4fb4b1d24
+            config-hash: 73925f26b20ddb1a2995993e3cf4b878fb5b3de34a75ea20650dccadc6306dba
           labels:
             app: upload
         spec:
@@ -5445,7 +5445,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: groundx
         spec:
@@ -5581,7 +5581,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: layout-webhook
         spec:
@@ -5703,7 +5703,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: pre-process
         spec:
@@ -5809,7 +5809,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: process
         spec:
@@ -5915,7 +5915,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: queue
         spec:
@@ -6021,7 +6021,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: summary-client
         spec:
@@ -6127,7 +6127,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 5a19af20014f7e64d3332d477a59acd52afecab0853ce7a28f6248db9e1af954
+            config-hash: 04b4d7ef653b919e44fd98fa24e6f7bbc5f93e87c96f23d4ffc1df54953e9f14
           labels:
             app: upload
         spec:
@@ -8451,7 +8451,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: groundx-service
         spec:
@@ -8593,7 +8593,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: layout-webhook
         spec:
@@ -8707,7 +8707,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: pre-process
         spec:
@@ -8805,7 +8805,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: process
         spec:
@@ -8903,7 +8903,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: queue
         spec:
@@ -9001,7 +9001,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: summary-client
         spec:
@@ -9099,7 +9099,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 0a3c152f5d304ef3b1f135d0d3f85782a9197b493f272d4c7c8b79d612e387ae
+            config-hash: 7797e273bcaa21ceb5b71ea6c7c0bdca0ec1ee5b972efb9d824728962c0d3028
           labels:
             app: upload
         spec:

--- a/src/groundx/tests/__snapshot__/metrics_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/metrics_test.yaml.snap
@@ -324,7 +324,7 @@
       template:
         metadata:
           annotations:
-            config-hash: f39c66e88c3881077aaf92791c9bf8f75c473d738d5fc5e5a5473747518db939
+            config-hash: 8f7d67e3ff2b4dea48b72c58d158038ea15513ba5b9e9774a4948ab17c4e4097
           labels:
             app: metrics
         spec:
@@ -1544,7 +1544,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 78df7f7453b3da3442c4b72e50196e83008f0464f2a555e6e8b3022d9af27e8e
+            config-hash: fb6fc3b11c346a7806c26179a2f316b560a011030516d9ccc654e0014bbc7f93
           labels:
             app: metrics
         spec:
@@ -1791,7 +1791,7 @@
       template:
         metadata:
           annotations:
-            config-hash: ba323975f09b0eb52ff8b0dcb18675ae627b4480ed65a46315cae9bbce637fdc
+            config-hash: d4193c69663c4febe3bfc7d4b0ce6817541d285211c7500c92677cc4b78029dd
           labels:
             app: metrics
         spec:
@@ -2035,7 +2035,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4af172bafeed4251168f72289094ce1f45a1410a60788515a2313d3faec61d6a
+            config-hash: 6d632c48853d4089175ae2be65e21b1d3e336b1f6e12cd66bd78c0fcf9df4b67
           labels:
             app: metrics
         spec:
@@ -3008,7 +3008,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 9490f5a9a6b0975741e72730d54939b8fa676a598205ee0644b4a643ef34da2d
+            config-hash: 967f8ae7fc70bd812a3f49d7b2dd08d1dbc82f3b56704c0a2969be22ea023438
           labels:
             app: metrics
         spec:

--- a/src/groundx/tests/__snapshot__/resources_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/resources_test.yaml.snap
@@ -1158,7 +1158,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -1429,7 +1429,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -5135,7 +5135,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -5393,7 +5393,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -6307,7 +6307,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -6594,7 +6594,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -7478,7 +7478,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -7731,7 +7731,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -11378,7 +11378,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx-service
@@ -11649,7 +11649,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -457,6 +457,7 @@ extract:
 
   download:
     enabled: false
+    threads: 1
 
     replicas:
       desired: 1


### PR DESCRIPTION
Two extraction preparation jobs sharing the default one-CPU pod reached their 600-second deadlines. Another copy of the same document running alone finished preparation in 266 seconds.

Set `extract.download.threads: 1` in `src/groundx/values.yaml` and its published `helm/values.yaml` mirror. This defaults download workers to one concurrent task, allowing additional jobs to queue. Explicit operator overrides still work.

The chart also recalculates download capacity from 180,000 to 90,000 tokens per minute. Existing configuration hashes trigger rollouts of extraction workers and enabled backend/metrics deployments that consume the shared configuration. Queue waiting may increase. Generated snapshots reflect these changes.

Validation: the full Helm gate passed (136 tests, 813 snapshots). Both chart surfaces passed Minikube rendering, default concurrency and explicit override checks. Render differences are limited to download concurrency, its capacity estimate, and rollout hashes. Arcadia legacy, Arcadia v1, generic v1, and ADP v1 workflow contracts are unchanged; no runtime document reruns or deployment were performed.
