### PR TITLE
Default extraction download concurrency to one

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -473,6 +473,7 @@ extract:
 
   download:
     enabled: false
+    threads: 1
 
     replicas:
       desired: 1

--- a/src/groundx/tests/__snapshot__/celery_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/celery_test.yaml.snap
@@ -666,7 +666,7 @@
         metadata:
           annotations:
             config-hash: c1973ea15bd9ac85e885f12ece25ff6cbda66e125632e817e4fda068309d5cde
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -830,7 +830,7 @@
         metadata:
           annotations:
             config-hash: c1973ea15bd9ac85e885f12ece25ff6cbda66e125632e817e4fda068309d5cde
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -976,7 +976,7 @@
         metadata:
           annotations:
             config-hash: c1973ea15bd9ac85e885f12ece25ff6cbda66e125632e817e4fda068309d5cde
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -3687,7 +3687,7 @@
         metadata:
           annotations:
             config-hash: 78308f99e67dfe2320ee3a82e39e9abed4d74a01b6cfe8fc665bec0b8ee197be
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -3852,7 +3852,7 @@
         metadata:
           annotations:
             config-hash: 78308f99e67dfe2320ee3a82e39e9abed4d74a01b6cfe8fc665bec0b8ee197be
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -3999,7 +3999,7 @@
         metadata:
           annotations:
             config-hash: 78308f99e67dfe2320ee3a82e39e9abed4d74a01b6cfe8fc665bec0b8ee197be
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -4807,7 +4807,7 @@
         metadata:
           annotations:
             config-hash: 7a2eea711ddd4ae8eafd493aa4115b03bc79d4bca6c7518aa16a273f6c275beb
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -4971,7 +4971,7 @@
         metadata:
           annotations:
             config-hash: 7a2eea711ddd4ae8eafd493aa4115b03bc79d4bca6c7518aa16a273f6c275beb
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -5117,7 +5117,7 @@
         metadata:
           annotations:
             config-hash: 7a2eea711ddd4ae8eafd493aa4115b03bc79d4bca6c7518aa16a273f6c275beb
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -5904,7 +5904,7 @@
         metadata:
           annotations:
             config-hash: a087924ef41f7340ac7005068d14bfca82943de3029968013f59d50e5eb97270
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -6069,7 +6069,7 @@
         metadata:
           annotations:
             config-hash: a087924ef41f7340ac7005068d14bfca82943de3029968013f59d50e5eb97270
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -6216,7 +6216,7 @@
         metadata:
           annotations:
             config-hash: a087924ef41f7340ac7005068d14bfca82943de3029968013f59d50e5eb97270
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:
@@ -8863,7 +8863,7 @@
         metadata:
           annotations:
             config-hash: 5a986c3ed73e7e9e46ac528ae84cd6853e7ec85233207e9c3983106c0d547de3
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-agent
         spec:
@@ -9023,7 +9023,7 @@
         metadata:
           annotations:
             config-hash: 5a986c3ed73e7e9e46ac528ae84cd6853e7ec85233207e9c3983106c0d547de3
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-download
         spec:
@@ -9165,7 +9165,7 @@
         metadata:
           annotations:
             config-hash: 5a986c3ed73e7e9e46ac528ae84cd6853e7ec85233207e9c3983106c0d547de3
-            supervisord-hash: a08a9897d41232df318545e5cafad66a1599dc0fe12a6c036a038f72b5b41346
+            supervisord-hash: 5bf4af831d996041a205cc3f1a10d245d88add89c850b940c5b44e0c423df98f
           labels:
             app: extract-save
         spec:

--- a/src/groundx/tests/__snapshot__/golang_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/golang_test.yaml.snap
@@ -794,7 +794,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: groundx
         spec:
@@ -940,7 +940,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: layout-webhook
         spec:
@@ -1058,7 +1058,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: pre-process
         spec:
@@ -1160,7 +1160,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: process
         spec:
@@ -1262,7 +1262,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: queue
         spec:
@@ -1364,7 +1364,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: summary-client
         spec:
@@ -1466,7 +1466,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 4976db04e6b7ca77ea3e4d39b5b9917cacd2a2f83e3d5200df0329e14988650b
+            config-hash: bb4d8556e9ebf4bbc3476da1c80120551a710b3e6630e732824ba90739d4acf9
           labels:
             app: upload
         spec:
@@ -3895,7 +3895,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: groundx
         spec:
@@ -4031,7 +4031,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: layout-webhook
         spec:
@@ -4153,7 +4153,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: pre-process
         spec:
@@ -4259,7 +4259,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: process
         spec:
@@ -4365,7 +4365,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: queue
         spec:
@@ -4471,7 +4471,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: summary-client
         spec:
@@ -4577,7 +4577,7 @@
       template:
         metadata:
           annotations:
-            config-hash: e1ced0ad29661a891d9832b678e998a1cc9f1fe9197a546f6e3d72cb15a905fc
+            config-hash: 9f194dfbebb1e45bf6bcd89e988672d12fcf5a6fc502a019babf40f26ee1531c
           labels:
             app: upload
         spec:
@@ -4684,7 +4684,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: groundx
         spec:
@@ -4816,7 +4816,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: layout-webhook
         spec:
@@ -4934,7 +4934,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: pre-process
         spec:
@@ -5036,7 +5036,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: process
         spec:
@@ -5138,7 +5138,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: queue
         spec:
@@ -5240,7 +5240,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: summary-client
         spec:
@@ -5342,7 +5342,7 @@
       template:
         metadata:
           annotations:
-            config-hash: a1a4399eca049612c56d9daa841072725a0cb5eac2f42a95f06091539dac5858
+            config-hash: 6eaa8c57ca09d7845d3e23b1ad4707359563cb75654cd8b06ca829418fa17746
           labels:
             app: upload
         spec:
@@ -5445,7 +5445,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: groundx
         spec:
@@ -5581,7 +5581,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: layout-webhook
         spec:
@@ -5703,7 +5703,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: pre-process
         spec:
@@ -5809,7 +5809,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: process
         spec:
@@ -5915,7 +5915,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: queue
         spec:
@@ -6021,7 +6021,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: summary-client
         spec:
@@ -6127,7 +6127,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73232a1513b9a509cf1b82383228096bdc5c08595720080ad627c404e283eebd
+            config-hash: aef46e2589fae68e000f3c7958156d4eb2dca0d414ef293cdb417859a81921f4
           labels:
             app: upload
         spec:
@@ -8451,7 +8451,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: groundx-service
         spec:
@@ -8593,7 +8593,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: layout-webhook
         spec:
@@ -8707,7 +8707,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: pre-process
         spec:
@@ -8805,7 +8805,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: process
         spec:
@@ -8903,7 +8903,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: queue
         spec:
@@ -9001,7 +9001,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: summary-client
         spec:
@@ -9099,7 +9099,7 @@
       template:
         metadata:
           annotations:
-            config-hash: cbad6b5004eec26f57deb8cf4862cc04ab15009877f659371ae786962f0f3f2a
+            config-hash: 50c0c4e194ce7d958ff5069980d931dc179baf4ab4fcb3847665c7c9a1fc661e
           labels:
             app: upload
         spec:

--- a/src/groundx/tests/__snapshot__/metrics_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/metrics_test.yaml.snap
@@ -324,7 +324,7 @@
       template:
         metadata:
           annotations:
-            config-hash: c36acea944503316bf714293e23cb84bc6b0d8a0e18b232bd058b3434a3aac03
+            config-hash: df56424bade9cf0b7d6eee0d6b62f978ef821233bd4976902049d199de276a42
           labels:
             app: metrics
         spec:
@@ -1544,7 +1544,7 @@
       template:
         metadata:
           annotations:
-            config-hash: d733c478c508c82465f4556be81163ed1c64efc56afdf5ed067b4e4ed518902b
+            config-hash: 2c062927974c3d59a93e426eecac76abf6d5185eaebfbfe9b825c3bedd4df88b
           labels:
             app: metrics
         spec:
@@ -1791,7 +1791,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 932de3e11d2f557dc4c2ec01cff3a5e29d722002bd42d62b1f73d70ce54d81de
+            config-hash: 81adaa4086a7ad56cd408e4dbb3d3debc19ee00e647a7589cf67963ef8bce8ae
           labels:
             app: metrics
         spec:
@@ -2035,7 +2035,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 73040c86ce760fcdf7e1cf589765eed2d021c16d206b0ddadf23a403651ff666
+            config-hash: 2b1535b7b02a73624fc38292f407939f611df0cf362ecec048b6097c34a1207e
           labels:
             app: metrics
         spec:
@@ -3008,7 +3008,7 @@
       template:
         metadata:
           annotations:
-            config-hash: 8ab266769a925e06c00097273321d33b3be0c30490fe48629ed56b25a46b8055
+            config-hash: 8050f8e23949bca44af9ee83968d7ff867886c5cff0ea88db016d81cbd2ee0f8
           labels:
             app: metrics
         spec:

--- a/src/groundx/tests/__snapshot__/resources_test.yaml.snap
+++ b/src/groundx/tests/__snapshot__/resources_test.yaml.snap
@@ -1196,7 +1196,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -1461,7 +1461,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -5282,7 +5282,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -5534,7 +5534,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -6486,7 +6486,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -6767,7 +6767,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -7687,7 +7687,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx
@@ -7934,7 +7934,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",
@@ -11699,7 +11699,7 @@
             - name: extract-api
               tokensPerMinute: 200000
             - name: extract-download
-              tokensPerMinute: 180000
+              tokensPerMinute: 90000
             - name: extract-save
               tokensPerMinute: 100000
             - name: groundx-service
@@ -11964,7 +11964,7 @@
         logfile=/dev/null
 
         [program:celery_worker_1]
-        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=2 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
+        command=celery -A celery_agents.app worker -n %(ENV_POD_NAME)s-w1 --loglevel=INFO --concurrency=1 --queues=download_queue --prefetch-multiplier=1 --max-tasks-per-child=100
         environment=
           CELERY_WORKER_NAME="%(ENV_POD_NAME)s-w1",
           LOCAL="0",

--- a/src/groundx/values.yaml
+++ b/src/groundx/values.yaml
@@ -473,6 +473,7 @@ extract:
 
   download:
     enabled: false
+    threads: 1
 
     replicas:
       desired: 1


### PR DESCRIPTION
Two extraction preparation jobs sharing a one-CPU pod reached their 600-second deadlines. Another copy of the same document running alone finished preparation in 266 seconds.

Set `extract.download.threads: 1` in `src/groundx/values.yaml` and its published chart mirror on `0.2.7`. Additional jobs queue instead of competing for the same CPU. Explicit operator overrides still work.

The derived download capacity estimate changes from 180,000 to 90,000 tokens per minute. Existing configuration hashes cause extraction workers and enabled backend/metrics services using shared configuration to roll when deployed. Queue waiting may increase. Generated snapshots reflect these effects.

Validation: full Helm gate, default concurrency and explicit override checks on both chart surfaces, and Minikube renders. Workflow contracts for Arcadia legacy, Arcadia v1, generic v1, and ADP v1 are unchanged. No runtime document reruns or deployment were performed.
